### PR TITLE
Fix video player preview image

### DIFF
--- a/packages/video-player-interface/README.md
+++ b/packages/video-player-interface/README.md
@@ -2,7 +2,7 @@
 
 An interface to select and display a video from YouTube, Vimeo or a local file from Directus.
 
-![The video interface, showing an open service drop-down with the options Directus, YouTube, and Vimeo, with YouTube selected, a video ID in the nearby text field, and a video player below the field.](https://raw.githubusercontent.com/directus-labs/extension-video-interface/main/docs/preview.png)
+![The video interface, showing an open service drop-down with the options Directus, YouTube, and Vimeo, with YouTube selected, a video ID in the nearby text field, and a video player below the field.](https://github.com/directus-labs/extensions/blob/c564cbad3b5cda2f8781c0a0dab91952b035ae86/packages/video-player-interface/docs/preview.png)
 
 ## Installation & Setup
 

--- a/packages/video-player-interface/README.md
+++ b/packages/video-player-interface/README.md
@@ -2,7 +2,7 @@
 
 An interface to select and display a video from YouTube, Vimeo or a local file from Directus.
 
-![The video interface, showing an open service drop-down with the options Directus, YouTube, and Vimeo, with YouTube selected, a video ID in the nearby text field, and a video player below the field.](https://github.com/directus-labs/extensions/blob/c564cbad3b5cda2f8781c0a0dab91952b035ae86/packages/video-player-interface/docs/preview.png)
+![The video interface, showing an open service drop-down with the options Directus, YouTube, and Vimeo, with YouTube selected, a video ID in the nearby text field, and a video player below the field.](https://raw.githubusercontent.com/directus-labs/extensions/main/packages/video-player-interface/docs/preview.png)
 
 ## Installation & Setup
 


### PR DESCRIPTION
The preview image in the video player README points to the old repo. I've updated it to point to the current `preview.png`. For this to properly show up in the marketplace it probably requires a new package version to be built.