### PR TITLE
Fix stores in tabular-layout

### DIFF
--- a/boilerplates/tabular-layout/src/core-clones/composables/use-alias-fields.ts
+++ b/boilerplates/tabular-layout/src/core-clones/composables/use-alias-fields.ts
@@ -37,7 +37,9 @@ type UsableAliasFields = {
  */
 export function useAliasFields(
     fields: Ref<string[]> | string[],
-    collection: Ref<string | null> | string | null
+    collection: Ref<string | null> | string | null,
+    // CORE CHANGES
+    system: Record<string, any>
 ): UsableAliasFields {
     const aliasedFields = computed(() => {
         const aliasedFields: Record<string, AliasFields> = {};
@@ -64,7 +66,11 @@ export function useAliasFields(
                 aliasedFields[field] = {
                     key: field,
                     fieldName,
-                    fields: adjustFieldsForDisplays([field], _collection),
+                    fields: adjustFieldsForDisplays(
+                        [field],
+                        _collection,
+                        system
+                    ),
                     aliased: false,
                 };
             } else {
@@ -74,18 +80,20 @@ export function useAliasFields(
                     key: field,
                     fieldName,
                     fieldAlias: alias,
-                    fields: adjustFieldsForDisplays([field], _collection).map(
-                        (displayField) => {
-                            if (displayField.includes(".")) {
-                                return `${alias}.${displayField
-                                    .split(".")
-                                    .slice(1)
-                                    .join(".")}`;
-                            } else {
-                                return alias;
-                            }
+                    fields: adjustFieldsForDisplays(
+                        [field],
+                        _collection,
+                        system
+                    ).map((displayField) => {
+                        if (displayField.includes(".")) {
+                            return `${alias}.${displayField
+                                .split(".")
+                                .slice(1)
+                                .join(".")}`;
+                        } else {
+                            return alias;
                         }
-                    ),
+                    }),
                     aliased: true,
                 };
             }

--- a/boilerplates/tabular-layout/src/core-clones/composables/use-extension.ts
+++ b/boilerplates/tabular-layout/src/core-clones/composables/use-extension.ts
@@ -6,15 +6,13 @@ import type {
 import type { Plural } from "@directus/types";
 import { pluralize } from "@directus/utils";
 import { Ref, computed, unref } from "vue";
-// CORE CHANGES
-import { useExtensions } from "@directus/extensions-sdk";
 
 export function useExtension<T extends AppExtensionType | HybridExtensionType>(
     type: T | Ref<T>,
-    name: string | Ref<string | null>
+    name: string | Ref<string | null>,
+    // CORE CHANGE
+    extensions: Record<string, any>
 ): Ref<AppExtensionConfigs[Plural<T>][number] | null> {
-    const extensions = useExtensions();
-
     return computed(() => {
         if (unref(name) === null) return null;
         return (

--- a/boilerplates/tabular-layout/src/core-clones/composables/use-page-size.ts
+++ b/boilerplates/tabular-layout/src/core-clones/composables/use-page-size.ts
@@ -1,15 +1,16 @@
 import { computed, unref, type ComputedRef, type MaybeRef } from "vue";
 // CORE CHANGES
 // import { useServerStore } from "@/stores/server";
-import { useStores } from "@directus/extensions-sdk";
 
 export function usePageSize<T = any>(
     availableSizes: MaybeRef<number[]>,
     mapCallback: (value: number, index: number, array: number[]) => T,
-    defaultSize = 25
+    defaultSize = 25,
+    // CORE CHANGE
+    system: Record<string, any>
 ): { sizes: ComputedRef<T[]>; selected: number } {
     // CORE CHANGES
-    const { useServerStore } = useStores();
+    const { useServerStore } = system.stores;
 
     const {
         info: { queryLimit },

--- a/boilerplates/tabular-layout/src/core-clones/utils/adjust-fields-for-displays.ts
+++ b/boilerplates/tabular-layout/src/core-clones/utils/adjust-fields-for-displays.ts
@@ -1,18 +1,18 @@
 import { computed } from "vue";
 import type { Field } from "@directus/types";
 // CORE IMPORTS
-import { useExtension } from "../../core-clones/composables/use-extension";
+import { useExtension } from "../composables/use-extension";
 // CORE CHANGES
 // import { useFieldsStore } from '@/stores/fields';
-import { useStores } from "@directus/extensions-sdk";
 
 export function adjustFieldsForDisplays(
     fields: readonly string[],
-    parentCollection: string
+    parentCollection: string,
+    // CORE CHANGES
+    system: Record<string, any>
 ): string[] {
-    // CHANGE: import useStores
-    const { useFieldsStore } = useStores();
-
+    // CORE CHANGE
+    const { useFieldsStore } = system.stores;
     const fieldsStore = useFieldsStore();
 
     const adjustedFields: string[] = fields
@@ -27,7 +27,8 @@ export function adjustFieldsForDisplays(
 
             const display = useExtension(
                 "display",
-                computed(() => field.meta?.display ?? null)
+                computed(() => field.meta?.display ?? null),
+                system.extensions
             );
 
             if (!display) return fieldKey;

--- a/boilerplates/tabular-layout/src/core-clones/utils/save-as-csv.ts
+++ b/boilerplates/tabular-layout/src/core-clones/utils/save-as-csv.ts
@@ -6,7 +6,6 @@ import { saveAs } from "file-saver";
 import { useAliasFields } from "../composables/use-alias-fields";
 import { useExtension } from "../composables/use-extension";
 // import { useFieldsStore } from "@/stores/fields";
-import { useStores } from "@directus/extensions-sdk";
 
 /**
  * Saves the given collection + items combination as a CSV file
@@ -14,9 +13,11 @@ import { useStores } from "@directus/extensions-sdk";
 export async function saveAsCSV(
     collection: string,
     fields: string[],
-    items: Item[]
+    items: Item[],
+    // CORE CHANGE
+    system: Record<string, any>
 ) {
-    const { useFieldsStore } = useStores();
+    const { useFieldsStore } = system.stores;
     const fieldsStore = useFieldsStore();
 
     const fieldsUsed: Record<string, Field | null> = {};
@@ -25,7 +26,7 @@ export async function saveAsCSV(
         fieldsUsed[key] = fieldsStore.getField(collection, key);
     }
 
-    const { getFromAliasedItem } = useAliasFields(fields, collection);
+    const { getFromAliasedItem } = useAliasFields(fields, collection, system);
 
     const parsedItems = [];
 
@@ -56,7 +57,8 @@ export async function saveAsCSV(
 
             const display = useExtension(
                 "display",
-                computed(() => fieldsUsed[key]?.meta?.display ?? null)
+                computed(() => fieldsUsed[key]?.meta?.display ?? null),
+                system.extensions
             );
 
             if (value !== undefined && value !== null) {

--- a/boilerplates/tabular-layout/src/core-clones/utils/sync-ref-property.ts
+++ b/boilerplates/tabular-layout/src/core-clones/utils/sync-ref-property.ts
@@ -10,7 +10,9 @@ export function syncRefProperty<R, T extends keyof R>(
             return ref.value?.[key] ?? unref(defaultValue);
         },
         set(value: R[T]) {
-            ref.value = Object.assign({}, ref.value, { [key]: value }) as R;
+            // CORE CHANGE
+            // ref.value = Object.assign({}, ref.value, { [key]: value }) as R;
+            ref.value = { ...ref.value, [key]: value } as R;
         },
     });
 }

--- a/boilerplates/tabular-layout/src/index.ts
+++ b/boilerplates/tabular-layout/src/index.ts
@@ -1,7 +1,8 @@
-import { computed, ref, toRefs, unref, watch } from "vue";
+import { computed, ref, toRefs, unref, watch, provide } from "vue";
 import {
     defineLayout,
     useStores,
+    useExtensions,
     useItems,
     useCollection,
     useSync,
@@ -35,7 +36,10 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
     },
     headerShadow: false,
     setup(props, { emit }) {
-        const { useFieldsStore } = useStores();
+        const system = { stores: useStores(), extensions: useExtensions() };
+        provide("system", system);
+
+        const { useFieldsStore } = system.stores;
         const fieldsStore = useFieldsStore();
 
         const selection = useSync(props, "selection", emit);
@@ -56,7 +60,8 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 
         const { aliasedFields, aliasQuery, aliasedKeys } = useAliasFields(
             fields,
-            collection
+            collection,
+            system
         );
 
         const fieldsWithRelationalAliased = computed(() =>
@@ -166,7 +171,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 
         function download() {
             if (!collection.value) return;
-            saveAsCSV(collection.value, fields.value, items.value);
+            saveAsCSV(collection.value, fields.value, items.value, system);
         }
 
         function toPage(newPage: number) {
@@ -221,7 +226,11 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 
             const fieldsWithRelational = computed(() => {
                 if (!props.collection) return [];
-                return adjustFieldsForDisplays(fields.value, props.collection);
+                return adjustFieldsForDisplays(
+                    fields.value,
+                    props.collection,
+                    system
+                );
             });
 
             return { sort, limit, page, fields, fieldsWithRelational };

--- a/boilerplates/tabular-layout/src/layout.vue
+++ b/boilerplates/tabular-layout/src/layout.vue
@@ -23,7 +23,7 @@
     // CORE CHANGES
     // import { useSync } from '@directus/composables';
     // import { useCollectionPermissions } from '@/composables/use-permissions';
-    import { useStores, useSync } from "@directus/extensions-sdk";
+    import { useSync } from "@directus/extensions-sdk";
 
     defineOptions({ inheritAttrs: false });
 
@@ -92,10 +92,13 @@
     const { t } = useI18n();
     const { collection } = toRefs(props);
 
+    // CORE CHANGE
+    const system = inject<Record<string, any>>("system")!;
+
     // CORE CHANGES
     const { sortAllowed } = useCollectionPermissions(collection);
     function useCollectionPermissions(collection: Ref<string>) {
-        const { usePermissionsStore } = useStores();
+        const { usePermissionsStore } = system.stores;
         const permissionsStore = usePermissionsStore();
 
         return {
@@ -130,7 +133,8 @@
     const { sizes: pageSizes, selected: selectedSize } = usePageSize<string>(
         [25, 50, 100, 250, 500, 1000],
         (value) => String(value),
-        props.limit
+        props.limit,
+        system
     );
 
     if (limitWritable.value !== selectedSize) {
@@ -139,7 +143,11 @@
 
     const fieldsWritable = useSync(props, "fields", emit);
 
-    const { getFromAliasedItem } = useAliasFields(fieldsWritable, collection);
+    const { getFromAliasedItem } = useAliasFields(
+        fieldsWritable,
+        collection,
+        system
+    );
 
     function addField(fieldKey: string) {
         fieldsWritable.value = [...fieldsWritable.value, fieldKey];


### PR DESCRIPTION
Because stores use `inject` within `useStores()` or `useExtensions` they are only available in the `setup()` function of the layout and can't be called throughout the extension. Therefore, the `system` variable now stores and provides the `stores` (`useStores()` object) and `extensions` (`useExtensions()` object).