### PR TITLE
Issue with pdf-viewer-interface url generation

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -6,3 +6,4 @@
 - timio23
 - Dominic-Marcelino
 - ukmadlz
+- carlosgonzalezpdn

--- a/packages/pdf-viewer-interface/src/interface.vue
+++ b/packages/pdf-viewer-interface/src/interface.vue
@@ -40,8 +40,8 @@
             return fieldValues.value[props.file_field] ?? null;
         });
         const fileURL = computed(() => {
-            if (!fileID.value) return null;
-            return `/assets/${fileID.value}`;
+            if (!fileID.value || !fileID.value.id) return null;
+            return `/assets/${fileID.value.id}`;
         });
         const fileIsValid = computed(() => !!fileID.value);
 


### PR DESCRIPTION
Fix how the pdf-viewer-interface retreive the identificator of the asset to generate a valid asset url.