### PR TITLE
Fix for running flows within relational items

### DIFF
--- a/packages/super-header-interface/CHANGELOG.md
+++ b/packages/super-header-interface/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.1.1 (2025-02-21)
+
+### Fixes
+- Fixed issue when running flows from action buttons from within nested relational items.
+
 ## 1.1.0 (2025-01-28)
 
 ### Fixes

--- a/packages/super-header-interface/package.json
+++ b/packages/super-header-interface/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@directus-labs/super-header-interface",
 	"type": "module",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "A super powerful header interface for Directus that allows you to create rich page headers with titles, subtitles, help information, and interactive actions. Perfect for enhancing the user experience with contextual information and quick access to common tasks.",
 	"license": "MIT",
 	"repository": {

--- a/packages/super-header-interface/src/composables/useFlows.ts
+++ b/packages/super-header-interface/src/composables/useFlows.ts
@@ -7,7 +7,7 @@ import { useRoute } from 'vue-router';
 const showForm = ref(false);
 const currentFlow = ref<any>(null);
 
-export function useFlows(collection: string) {
+export function useFlows(collection: string, primaryKey: string | number | null) {
 	const { t } = useI18n();
 	const api = useApi();
 	const formValues = inject('values') as Record<string, any>;
@@ -91,7 +91,7 @@ export function useFlows(collection: string) {
 			const response = await api.post(`/flows/trigger/${flow.id}`, {
 				...formData,
 				collection,
-				keys: route.params?.primaryKey ? [route.params.primaryKey] : [],
+				keys: primaryKey ? [primaryKey] : [],
 				$values: formValues.value,
 				$route: {
 					params: route.params,

--- a/packages/super-header-interface/src/interface.vue
+++ b/packages/super-header-interface/src/interface.vue
@@ -19,7 +19,7 @@ const { t } = useI18n();
 const { useFieldsStore } = useStores();
 const fieldsStore = useFieldsStore();
 
-const { fetchFlows, showForm, submitFlow, currentFlow, runFlow } = useFlows(props.collection);
+const { fetchFlows, showForm, submitFlow, currentFlow, runFlow } = useFlows(props.collection, props.primaryKey);
 
 const expanded = ref(false);
 const flowFormData = ref<Record<string, any>>({});


### PR DESCRIPTION
Fixes a bug where we were using the primary key from the route, instead of the one passed via props.

Didn't find this one initially because it only causes issues when you're trying to run a flow from within a drawer.