### PR TITLE
feat: add Arabic language support

### DIFF
--- a/packages/ai-translator-operation/src/languages.js
+++ b/packages/ai-translator-operation/src/languages.js
@@ -1,4 +1,5 @@
 export default [
+	{ value: 'AR', text: 'Arabic' },
 	{ value: 'BG', text: 'Bulgarian' },
 	{ value: 'CS', text: 'Czech' },
 	{ value: 'DA', text: 'Danish' },


### PR DESCRIPTION
This PR adds Arabic language support to the available target languages, as discussed in #180.

Changes:
- Added Arabic (AR) to the supported languages list

This simple addition allows users to leverage DeepL's Arabic translation capabilities which are already supported by their API (see https://developers.deepl.com/docs/getting-started/supported-languages#translation-target-languages).

Related issue: #180 