### PR TITLE
add env variable to enable logging

### DIFF
--- a/packages/collaborative-editing/README.md
+++ b/packages/collaborative-editing/README.md
@@ -57,6 +57,10 @@ cd PATH_TO_DIRECTUS_CORE/api/extensions/collaborative-editing
 pnpm i && pnpm dev
 ```
 
+## Logging
+
+To enable logging, add the `REALTIME_LOGS_ENABLED` environment variable in the `.env` file and set it to `true`.
+
 ## Architecture
 
 ### Frontend

--- a/packages/collaborative-editing/src/hooks/index.ts
+++ b/packages/collaborative-editing/src/hooks/index.ts
@@ -19,6 +19,8 @@ import { handleBroadcast, useBus } from './lib/bus';
 import { useSockets } from './lib/use-sockets';
 import { BroadcastPayload } from './types';
 
+const excludedFromLogs = ['update', 'pong'] as const;
+
 export default defineHook(async ({ action, filter }, ctx) => {
 	const { env, services, database, getSchema } = ctx;
 
@@ -43,7 +45,10 @@ export default defineHook(async ({ action, filter }, ctx) => {
 		if (!client.accountability?.user) return;
 		if (message.type !== 'realtime-connect' && sockets.has(client.uid) === false) return;
 
-		ctx.logger.info(`[realtime:message] Client ${client.uid} sent message ${message.type}`);
+		// Only log message types that are not 'update' or 'pong'
+		if (env.REALTIME_LOGS_ENABLED && !excludedFromLogs.includes(message.type)) {
+			ctx.logger.info(`[realtime:message] Client ${client.uid} sent message ${message.type}`);
+		}
 
 		const { type, ...payload } = message;
 		const messageCtx = { ...ctx, database: eventCtx.database };


### PR DESCRIPTION
This PR prevents the busier event types from being logged and requires an env variable to enable logging.

https://linear.app/directus/issue/NOW-1012/configure-logging

Fixes #robl/now-1012