### PR TITLE
Fix migrationOptionsSelections being null

### DIFF
--- a/packages/migration-bundle/src/migration-module/module.vue
+++ b/packages/migration-bundle/src/migration-module/module.vue
@@ -58,7 +58,7 @@ export default defineComponent({
 			},
 		]);
 
-		const migrationOptionsSelections = ref<Options[]>(migrationOptions.value.map((o) => o.value as Options));
+		const migrationOptionsSelections = ref<Options[] | null>(migrationOptions.value.map((o) => o.value as Options));
 
 		const scope = reactive<Record<Options, boolean>>({
 			users: false,
@@ -84,7 +84,7 @@ export default defineComponent({
 			lockInterface.value = true;
 			dataChunk.value = '';
 
-			migrationOptionsSelections.value.forEach((o) => {
+			(migrationOptionsSelections.value ?? []).forEach((o) => {
 				scope[o] = true;
 			});
 


### PR DESCRIPTION
When deselecting all options, instead of having a empty array, the `v-select` models to null, thus `null.forEach` fails.

Fixes #222 