### PR TITLE
Patch resend operation version

### DIFF
--- a/packages/resend-operation/package.json
+++ b/packages/resend-operation/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@directus-labs/resend-operation",
 	"type": "module",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Resend API operation for Directus Flows. Send emails, update domains, and more.",
 	"keywords": [
 		"directus",


### PR DESCRIPTION
The published version is `1.0.1` and not `1.0.0`. 
https://www.npmjs.com/package/@directus-labs/resend-operation