### PR TITLE
Flow Trigger Bundle: Added option to automatically refresh current item after Flow completes and also checks for unsaved changes before running.

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -6,3 +6,4 @@
 - timio23
 - Dominic-Marcelino
 - ukmadlz
+- MarkBurvs

--- a/packages/flow-trigger-bundle/package.json
+++ b/packages/flow-trigger-bundle/package.json
@@ -46,7 +46,8 @@
 	"dependencies": {
 		"@directus/format-title": "11.0.0",
 		"@directus/types": "11.1.1",
-		"vue-i18n": "9.13.1"
+		"vue-i18n": "9.13.1",
+		"lodash-es": "^4.17.21"
 	},
 	"devDependencies": {
 		"@directus/extensions-sdk": "12.0.1",

--- a/packages/flow-trigger-bundle/src/flow-triggers-interface/index.ts
+++ b/packages/flow-trigger-bundle/src/flow-triggers-interface/index.ts
@@ -43,6 +43,21 @@ export default defineInterface({
 					},
 				},
 			},
+			{
+				field: 'autoRefresh',
+				name: 'Auto Refresh',
+				type: 'boolean',
+				meta: {
+					interface: 'boolean',
+					options: {
+						label: 'Automatically refresh item data after flow completes',
+					},
+					width: 'full',
+				},
+				schema: {
+					default_value: true,
+				},
+			},
 		];
 	},
 });

--- a/packages/flow-trigger-bundle/src/flow-triggers-panel/panel.vue
+++ b/packages/flow-trigger-bundle/src/flow-triggers-panel/panel.vue
@@ -29,6 +29,7 @@ const permissionsStore = usePermissionsStore();
 const {
 	runFlow,
 	runningFlows,
+	checkingUnsavedChanges,
 	onTriggerClick,
 	getButtonText,
 	getButtonIcon,
@@ -41,6 +42,7 @@ const {
 } = useFlowTriggers({
 	collection: (trigger) => trigger.collection,
 	keys: (trigger) => trigger.keys,
+	autoRefresh: () => false, // Don't refresh the page when used in a panel
 });
 
 const triggers = computed(() => {
@@ -56,7 +58,7 @@ const triggers = computed(() => {
 		<div v-for="{ trigger } in triggers" class="trigger">
 			<v-button
 				full-width
-				:loading="runningFlows.includes(trigger.flowId)"
+				:loading="runningFlows.includes(trigger.flowId) || checkingUnsavedChanges.includes(trigger.flowId)"
 				@click="onTriggerClick(trigger)"
 			>
 				<v-icon :name="getButtonIcon(trigger)" small left />


### PR DESCRIPTION
Fixes https://github.com/directus-labs/extensions/issues/61 and https://github.com/directus-labs/extensions/issues/72

## Features Added

### 1. Option to Auto-Refresh After Flow Execution
- Give the user the option to automatically refresh current item after successful flow execution
- New "Auto Refresh" boolean configuration option in interface settings

### 2. Unsaved Changes Detection
- Detects unsaved form changes before triggering flows with auto-refresh enabled
- Uses deep comparison (lodash-es `isEqual`) to avoid false positives from object reference changes
- Shows warning dialog with "Cancel" or "Discard Changes & Continue" options

## Benefits
- **Better UX**: Users see flow results immediately without having to manually refresh item
- **Data Safety**: Prevents accidental loss of unsaved changes

## Screenshots
<img width="853" height="527" alt="Auto-Refresh-Button" src="https://github.com/user-attachments/assets/b08391fa-7ee8-4075-a291-c09a7c6bf6fb" />
<img width="878" height="502" alt="Unsaved Changes Warning" src="https://github.com/user-attachments/assets/0884fa7f-4128-4276-9a24-925b329811af" />
