### PR TITLE
Disable Readme-Workflow on forks

### DIFF
--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -21,6 +21,7 @@ env:
 
 jobs:
   update-readme:
+    if: github.repository == 'directus-labs/extensions'
     name: Update & PR
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Currently the daily readme-action tries to run on forks, which will most likely fail due to the missing token. This disables the action for forks.

[GH-Docs](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-only-run-job-for-specific-repository)

Directus-Repo:
We use the same approach on the directus repo to disable the "[stale-issues](https://github.com/Dominic-Marcelino/directus/blob/main/.github/workflows/stale-issues.yml)" action