### PR TITLE
feat(migration-bundle): add collection-level selection and file filtering

### DIFF
--- a/packages/migration-bundle/CHANGELOG.md
+++ b/packages/migration-bundle/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+## 1.2.0 - 2026-02-24
+
+> **Development Note:** This release was developed with assistance from Claude Code (Anthropic's AI coding assistant).
+
+### Features
+
+- **Collection-Level Selection:** Users can now select specific collections to migrate instead of migrating all content at once. This feature addresses [Issue #266](https://github.com/directus-labs/extensions/issues/266) and [Issue #294](https://github.com/directus-labs/extensions/issues/294).
+  - Schema filtering: Only selected collections' schemas are migrated
+  - Content filtering: Only selected collections' data is migrated
+  - Parent group collections are automatically included when child collections are selected
+
+- **File Filtering by Collection:** Files are now filtered based on selected collections. Only files referenced by the selected collections are migrated, reducing migration payload size and improving performance.
+
+- **Content Collection Selector UI:** New multi-select interface in the Migration Options to choose which collections to migrate.
+
+- **Environment Variable Support:**
+  - `MIGRATION_BUNDLE_SELECTED_COLLECTIONS`: Comma-separated list of collections to include
+  - `MIGRATION_BUNDLE_EXCLUDED_COLLECTIONS`: Comma-separated list of collections to exclude
+
+### Improvements
+
+- **Schema Option Checkbox:** Added "Schema" as a selectable migration option (previously schema was always migrated)
+- **Filtered Panels/Flows/Presets:** Dashboard panels, flows, and presets are now filtered based on their collection references
+- **Debug Logging:** Added debug output during schema filtering for troubleshooting
+
+### Important Notes
+
+#### PostgreSQL Requirement for Target Instance
+
+Due to a known Directus bug ([GitHub Issue #20428](https://github.com/directus/directus/issues/20428)), schema migrations may fail on MySQL target instances. The issue occurs because Directus automatically converts `char(36)` to `varchar(36)` in schema diffs for PostgreSQL compatibility, which breaks MySQL foreign key constraints.
+
+**Recommendation:** Use PostgreSQL for the target (destination) Directus instance to ensure reliable schema migrations.
+
+| Target Database | Schema Apply | Status |
+|-----------------|--------------|--------|
+| PostgreSQL | Works correctly | ✅ Recommended |
+| MySQL | May fail with FK constraint errors | ⚠️ Known issue |
+
+### Internal Changes
+
+- Refactored `extract-data.ts` to filter collections list with parent group resolution
+- Added `filter-schema.ts` utility for schema snapshot filtering
+- Added `filter-schema-diff.ts` utility for diff response filtering
+- Modified `extract-system.ts` to filter panels, flows, presets, and comments by collection
+
+---
+
+## 1.1.1 - Previous Release
+
+- Initial release with category-level migration options
+- Support for migrating content, users, flows, dashboards, extensions, presets, and comments

--- a/packages/migration-bundle/README.md
+++ b/packages/migration-bundle/README.md
@@ -108,6 +108,55 @@ This approach provides:
 ![Customise the module](https://raw.githubusercontent.com/directus-labs/extensions/main/packages/migration-bundle/docs/migration-module-customize.jpg)
 
 
+## Collection-Level Selection
+
+> **New in v1.2.0** - Developed with assistance from Claude Code (Anthropic's AI coding assistant).
+
+You can now select specific collections to migrate instead of migrating all content at once. This feature is useful for:
+- Large schemas where only specific collections need synchronization
+- Reducing migration payload size
+- Partial content migrations between instances
+
+### How to Use Collection Filtering
+
+1. Configure your migration as usual (destination URL and token)
+2. Click **Check** to validate the connection
+3. In Migration Options, check **Schema** and/or **Content**
+4. A collection selector will appear - choose which collections to migrate
+5. Start the migration
+
+**Note:** When you select child collections, their parent group collections are automatically included to maintain schema integrity.
+
+### File Filtering
+
+Files are automatically filtered based on your collection selection. Only files that are referenced by the selected collections will be migrated, significantly reducing migration time for partial migrations.
+
+### Environment Variables for Collection Filtering
+
+```bash
+# Include only specific collections (comma-separated)
+MIGRATION_BUNDLE_SELECTED_COLLECTIONS=articles,authors,categories
+
+# Exclude specific collections (used if SELECTED is not set)
+MIGRATION_BUNDLE_EXCLUDED_COLLECTIONS=logs,temp_data,analytics
+```
+
+## Important: PostgreSQL Requirement for Target Instance
+
+Due to a known Directus bug ([GitHub Issue #20428](https://github.com/directus/directus/issues/20428)), schema migrations may fail on MySQL target instances.
+
+**Technical Details:**
+- Directus automatically converts `char(36)` to `varchar(36)` in schema diffs for PostgreSQL compatibility
+- This conversion triggers MySQL foreign key constraint errors: `Cannot change column 'X': used in a foreign key constraint`
+- The issue affects any migration that includes schema changes
+
+**Recommendation:** Use **PostgreSQL** for the target (destination) Directus instance to ensure reliable schema migrations.
+
+| Target Database | Schema Migration | Recommendation |
+|-----------------|------------------|----------------|
+| PostgreSQL | ✅ Works correctly | **Recommended** |
+| MySQL | ⚠️ May fail with FK errors | Use with caution |
+
 ## Permissions
 
-This extension requires admin privilages on both instances to ensure all data is accessible and writable.
+This extension requires admin privileges on both instances to ensure all data is accessible and writable.

--- a/packages/migration-bundle/package.json
+++ b/packages/migration-bundle/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@directus-labs/migration-bundle",
 	"type": "module",
-	"version": "1.1.1",
+	"version": "1.2.0",
 	"description": "Migrate from the current source Directus instance to another target Directus instance.",
 	"license": "MIT",
 	"repository": {

--- a/packages/migration-bundle/src/migration-endpoint/composables/extract-data.ts
+++ b/packages/migration-bundle/src/migration-endpoint/composables/extract-data.ts
@@ -34,30 +34,105 @@ async function extractContent({
 	try {
 		res.write('* Fetching collections');
 
-		const collections: Collection[] = await collectionService.readByQuery({
+		// Load all collections first
+		const allCollections: Collection[] = await collectionService.readByQuery({
 			limit: -1,
 		});
 
-		res.write(' ...done\r\n\r\n');
+		// Fix 8: Filter collections based on scope (same logic as fullData/singletons)
+		let collections = allCollections.filter(c => !c.collection.startsWith('directus_'));
+
+		const hasContentFilter = scope.contentCollections && scope.contentCollections.length > 0;
+		const hasSelectedFilter = scope.selectedCollections && scope.selectedCollections.length > 0;
+		const hasExcludedFilter = scope.excludedCollections && scope.excludedCollections.length > 0;
+
+		if (hasContentFilter || hasSelectedFilter) {
+			// Build initial set of included collection names
+			const selectedNames = hasContentFilter
+				? scope.contentCollections!
+				: scope.selectedCollections!;
+
+			const includedNames = new Set<string>(selectedNames);
+
+			// Recursively add parent groups (same logic as filter-schema.ts)
+			let changed = true;
+			let iterations = 0;
+			const maxIterations = 100;
+
+			while (changed && iterations < maxIterations) {
+				changed = false;
+				iterations++;
+				for (const c of allCollections) {
+					if (includedNames.has(c.collection) && c.meta?.group) {
+						if (!includedNames.has(c.meta.group)) {
+							includedNames.add(c.meta.group);
+							changed = true;
+						}
+					}
+				}
+			}
+
+			// Filter collections to only include selected + parent groups
+			collections = collections.filter(c => includedNames.has(c.collection));
+		}
+		else if (hasExcludedFilter) {
+			collections = collections.filter(c =>
+				!scope.excludedCollections!.includes(c.collection)
+			);
+		}
+
+		res.write(` (${collections.length} collections) ...done\r\n\r\n`);
 
 		res.write('* Fetching fields');
 		const primaryKeyMap = await getCollectionPrimaryKeys(fieldService);
 		res.write(' ...done\r\n\r\n');
 
 		res.write('* Fetching full data');
-		const fullData: UserCollectionItems[] = scope.content ? await loadFullData(collections, ItemsService, primaryKeyMap, accountability, schema) : [];
+		const fullData: UserCollectionItems[] = scope.content ? await loadFullData(collections, ItemsService, primaryKeyMap, accountability, schema, scope) : [];
 		res.write(' ...');
 		await saveToFile(fullData, 'items_full_data', fileService, folder, storage);
 		res.write('done\r\n\r\n');
 
 		res.write('* Fetching singletons');
-		const singletons: UserCollectionItem[] = scope.content ? await loadSingletons(collections, ItemsService, accountability, schema) : [];
+		const singletons: UserCollectionItem[] = scope.content ? await loadSingletons(collections, ItemsService, accountability, schema, scope) : [];
 		res.write(' ...');
 		await saveToFile(singletons, 'items_singleton', fileService, folder, storage);
 		res.write('done\r\n\r\n');
 
 		res.write('* Fetching files');
-		const files: File[] = scope.content ? await fileService.readByQuery({ fields: directusFileFields, filter: { _or: [{ folder: { _neq: folder } }, { folder: { _null: true } }] }, limit: -1 }) : [];
+		// Fix 6.3: Filter files based on selected collections
+		let files: File[] = [];
+		if (scope.content) {
+			const contentCols = scope.contentCollections?.length ? scope.contentCollections
+				: (scope.selectedCollections?.length ? scope.selectedCollections : null);
+
+			if (contentCols && contentCols.length > 0) {
+				// Get file IDs from selected collections
+				const fileIds = await getFileIdsFromCollections(contentCols, ItemsService, fieldService, accountability, schema);
+				res.write(` (${fileIds.size} files from ${contentCols.length} collections)`);
+
+				if (fileIds.size > 0) {
+					files = await fileService.readByQuery({
+						fields: directusFileFields,
+						filter: {
+							_and: [
+								{ id: { _in: Array.from(fileIds) } },
+								{ _or: [{ folder: { _neq: folder } }, { folder: { _null: true } }] },
+							],
+						},
+						limit: -1,
+					});
+				}
+			}
+			else {
+				// No filtering - get all files
+				files = await fileService.readByQuery({
+					fields: directusFileFields,
+					filter: { _or: [{ folder: { _neq: folder } }, { folder: { _null: true } }] },
+					limit: -1,
+				});
+			}
+		}
 		res.write(' ...');
 		await saveToFile(files, 'files', fileService, folder, storage);
 		res.write('done\r\n\r\n');
@@ -120,11 +195,25 @@ async function extractSingleton(collection: string, ItemsService: any, accountab
 	return await itemService.readSingleton({});
 }
 
-async function loadFullData(collections: Collection[], itemService: any, primaryKeyMap: any, accountability: Accountability, schema: SchemaOverview): Promise<UserCollectionItems[]> {
+async function loadFullData(collections: Collection[], itemService: any, primaryKeyMap: any, accountability: Accountability, schema: SchemaOverview, scope: Scope): Promise<UserCollectionItems[]> {
 	const userCollections = collections
 		.filter((item) => !item.collection.startsWith('directus_', 0))
 		.filter((item) => item.schema !== null)
-		.filter((item) => !item.meta?.singleton);
+		.filter((item) => !item.meta?.singleton)
+		// Collection-level filtering for content
+		// If contentCollections is specified, use that; otherwise fall back to selectedCollections/excludedCollections
+		.filter((item) => {
+			if (scope.contentCollections && scope.contentCollections.length > 0) {
+				return scope.contentCollections.includes(item.collection);
+			}
+			if (scope.selectedCollections && scope.selectedCollections.length > 0) {
+				return scope.selectedCollections.includes(item.collection);
+			}
+			if (scope.excludedCollections && scope.excludedCollections.length > 0) {
+				return !scope.excludedCollections.includes(item.collection);
+			}
+			return true;
+		});
 
 	return await Promise.all(userCollections.map(async (collection) => {
 		const name = collection.collection;
@@ -137,10 +226,24 @@ async function loadFullData(collections: Collection[], itemService: any, primary
 	}));
 }
 
-async function loadSingletons(collections: Collection[], itemService: any, accountability: Accountability, schema: SchemaOverview): Promise<UserCollectionItem[]> {
+async function loadSingletons(collections: Collection[], itemService: any, accountability: Accountability, schema: SchemaOverview, scope: Scope): Promise<UserCollectionItem[]> {
 	const singletonCollections = collections
 		.filter((item) => !item.collection.startsWith('directus_', 0))
-		.filter((item) => item.meta?.singleton);
+		.filter((item) => item.meta?.singleton)
+		// Collection-level filtering for content
+		// If contentCollections is specified, use that; otherwise fall back to selectedCollections/excludedCollections
+		.filter((item) => {
+			if (scope.contentCollections && scope.contentCollections.length > 0) {
+				return scope.contentCollections.includes(item.collection);
+			}
+			if (scope.selectedCollections && scope.selectedCollections.length > 0) {
+				return scope.selectedCollections.includes(item.collection);
+			}
+			if (scope.excludedCollections && scope.excludedCollections.length > 0) {
+				return !scope.excludedCollections.includes(item.collection);
+			}
+			return true;
+		});
 
 	return await Promise.all(singletonCollections.map(async (collection) => {
 		const name = collection.collection;
@@ -172,6 +275,60 @@ function getPrimaryKey(collectionsMap: any, collection: string) {
 	}
 
 	return collectionsMap[collection];
+}
+
+// Fix 6.3: Get file IDs from selected collections
+async function getFileIdsFromCollections(
+	collections: string[],
+	ItemsService: any,
+	fieldService: any,
+	accountability: Accountability,
+	schema: SchemaOverview,
+): Promise<Set<string>> {
+	const fileIds = new Set<string>();
+
+	// Get all fields to find file-type fields
+	const allFields = await fieldService.readAll();
+	if (!allFields) return fileIds;
+
+	// Find file-type fields in selected collections
+	const fileFields: Array<{ collection: string; field: string }> = [];
+	for (const field of allFields) {
+		if (!collections.includes(field.collection)) continue;
+
+		// Check for file field (uuid with file interface or special)
+		const isFileField = field.type === 'uuid' &&
+			(field.meta?.interface === 'file' ||
+				field.meta?.interface === 'file-image' ||
+				field.meta?.special?.includes('file'));
+
+		if (isFileField) {
+			fileFields.push({ collection: field.collection, field: field.field });
+		}
+	}
+
+	// Query each collection for file IDs
+	for (const { collection, field } of fileFields) {
+		try {
+			const itemService = new ItemsService(collection, { accountability, schema });
+			const items = await itemService.readByQuery({
+				fields: [field],
+				filter: { [field]: { _nnull: true } },
+				limit: -1,
+			});
+
+			for (const item of items) {
+				if (item[field]) {
+					fileIds.add(item[field]);
+				}
+			}
+		}
+		catch (error) {
+			console.error(`Failed to get files from ${collection}.${field}:`, error);
+		}
+	}
+
+	return fileIds;
 }
 
 export default extractContent;

--- a/packages/migration-bundle/src/migration-endpoint/composables/extract-system.ts
+++ b/packages/migration-bundle/src/migration-endpoint/composables/extract-system.ts
@@ -1,6 +1,25 @@
 import type { Accountability, Permission, Preset, SchemaOverview, Settings, Share } from '@directus/types';
 import type { Access, CommentRaw, DashboardRaw, DirectusError, Extension, Folder, ModifiedFlowRaw, OperationRaw, PanelRaw, PolicyRaw, RoleRaw, Scope, SystemExtract, Translation, UserRaw } from '../../types/extension';
 import saveToFile from '../../utils/save-file';
+
+function shouldIncludeCollection(collectionName: string, scope: Scope): boolean {
+	const { selectedCollections, excludedCollections } = scope;
+
+	// If no filtering specified, include all
+	if ((!selectedCollections || selectedCollections.length === 0) &&
+		(!excludedCollections || excludedCollections.length === 0)) {
+		return true;
+	}
+
+	if (selectedCollections && selectedCollections.length > 0) {
+		return selectedCollections.includes(collectionName);
+	}
+	if (excludedCollections && excludedCollections.length > 0) {
+		return !excludedCollections.includes(collectionName);
+	}
+	return true;
+}
+
 import {
 	directusDashboardFields,
 	directusFlowFields,
@@ -100,6 +119,8 @@ async function extractSystemData({ res, services, accountability, schema, scope,
 		}
 
 		res.write(scope.content ? '* Fetching folders' : '* Skipping folders\r\n\r\n');
+		// TODO Fix 6.4: Filter folders based on which files are being migrated
+		// Currently loads all folders - duplicates are prevented in migrate-folders.ts
 		const folders: Folder[] = scope.content ? await folderService.readByQuery({ fields: directusFolderFields, filter: { id: { _neq: folder } }, limit: -1 }) : [];
 
 		if (scope.content) {
@@ -118,7 +139,16 @@ async function extractSystemData({ res, services, accountability, schema, scope,
 		}
 
 		res.write(scope.dashboards ? '* Fetching panels' : '* Skipping panels\r\n\r\n');
-		const panels: PanelRaw[] = scope.dashboards ? await panelService.readByQuery({ fields: directusPanelFields, limit: -1 }) : [];
+		let panels: PanelRaw[] = scope.dashboards ? await panelService.readByQuery({ fields: directusPanelFields, limit: -1 }) : [];
+
+		// Filter panels by options.collection if collection filtering is active
+		if (scope.dashboards && panels.length > 0) {
+			panels = panels.filter(panel => {
+				// Panels without collection reference are always included
+				if (!panel.options?.collection) return true;
+				return shouldIncludeCollection(panel.options.collection, scope);
+			});
+		}
 
 		if (scope.dashboards) {
 			res.write(' ...');
@@ -127,7 +157,16 @@ async function extractSystemData({ res, services, accountability, schema, scope,
 		}
 
 		res.write(scope.flows ? '* Fetching flows' : '* Skipping flows\r\n\r\n');
-		const flows: ModifiedFlowRaw[] = scope.flows ? await flowService.readByQuery({ fields: directusFlowFields, limit: -1 }) : [];
+		let flows: ModifiedFlowRaw[] = scope.flows ? await flowService.readByQuery({ fields: directusFlowFields, limit: -1 }) : [];
+
+		// Filter flows by options.collection if collection filtering is active
+		if (scope.flows && flows.length > 0) {
+			flows = flows.filter(flow => {
+				// Flows without collection reference are always included
+				if (!flow.options?.collection) return true;
+				return shouldIncludeCollection(flow.options.collection, scope);
+			});
+		}
 
 		if (scope.flows) {
 			res.write(' ...');
@@ -136,7 +175,13 @@ async function extractSystemData({ res, services, accountability, schema, scope,
 		}
 
 		res.write(scope.flows ? '* Fetching operations' : '* Skipping operations\r\n\r\n');
-		const operations: OperationRaw[] = scope.flows ? await operationService.readByQuery({ fields: directusOperationFields, limit: -1 }) : [];
+		let operations: OperationRaw[] = scope.flows ? await operationService.readByQuery({ fields: directusOperationFields, limit: -1 }) : [];
+
+		// Filter operations: only include operations belonging to included flows
+		if (scope.flows && operations.length > 0) {
+			const includedFlowIds = new Set(flows.map(f => f.id));
+			operations = operations.filter(op => includedFlowIds.has(op.flow));
+		}
 
 		if (scope.flows) {
 			res.write(' ...');
@@ -157,7 +202,16 @@ async function extractSystemData({ res, services, accountability, schema, scope,
 		res.write('done\r\n\r\n');
 
 		res.write(scope.presets ? '* Fetching presets' : '* Skipping presets');
-		const presets: Preset[] = scope.presets ? await presetService.readByQuery({ fields: directusPresetFields, limit: -1 }) : [];
+		let presets: Preset[] = scope.presets ? await presetService.readByQuery({ fields: directusPresetFields, limit: -1 }) : [];
+
+		// Filter presets by collection if collection filtering is active
+		if (scope.presets && presets.length > 0) {
+			presets = presets.filter(preset => {
+				// Global presets (no collection) are always included
+				if (!preset.collection) return true;
+				return shouldIncludeCollection(preset.collection, scope);
+			});
+		}
 
 		if (scope.presets) {
 			res.write(' ...');
@@ -175,7 +229,12 @@ async function extractSystemData({ res, services, accountability, schema, scope,
 		}
 
 		res.write(scope.comments ? '* Fetching comments' : '* Skipping comments');
-		const comments: CommentRaw[] = scope.comments ? await commentService.readByQuery({ limit: -1 }) : [];
+		let comments: CommentRaw[] = scope.comments ? await commentService.readByQuery({ limit: -1 }) : [];
+
+		// Filter comments by collection if collection filtering is active
+		if (scope.comments && comments.length > 0) {
+			comments = comments.filter(comment => shouldIncludeCollection(comment.collection, scope));
+		}
 
 		if (scope.comments) {
 			res.write(' ...');

--- a/packages/migration-bundle/src/migration-endpoint/composables/migrate-folders.ts
+++ b/packages/migration-bundle/src/migration-endpoint/composables/migrate-folders.ts
@@ -29,13 +29,23 @@ async function migrateFolders({ res, client, folders, dry_run = false }: { res: 
 
 		const existingFolderIds = new Set(existingFolders.map((folder) => folder.id));
 
-		const foldersToAdd = folders.filter((folder) => {
-			if (existingFolderIds.has(folder.id)) {
-				return false;
-			}
+		// Fix 6.5: Track skipped folders for better logging
+		const foldersToAdd: Folder[] = [];
+		const skippedFolders: Folder[] = [];
 
-			return true;
-		});
+		for (const folder of folders) {
+			if (existingFolderIds.has(folder.id)) {
+				skippedFolders.push(folder);
+			}
+			else {
+				foldersToAdd.push(folder);
+			}
+		}
+
+		// Log skipped folders
+		if (skippedFolders.length > 0) {
+			res.write(`* [Remote] Skipping ${skippedFolders.length} existing folder(s): ${skippedFolders.map(f => f.name).join(', ')}\r\n\r\n`);
+		}
 
 		res.write(foldersToAdd.length > 0 ? `* [Remote] Uploading ${foldersToAdd.length} ${foldersToAdd.length > 1 ? 'Folders' : 'Folder'} ` : '* No Folders to migrate\r\n\r\n');
 

--- a/packages/migration-bundle/src/migration-endpoint/composables/migrate-schema.ts
+++ b/packages/migration-bundle/src/migration-endpoint/composables/migrate-schema.ts
@@ -2,12 +2,21 @@ import type { RestClient, SchemaDiffOutput, SchemaSnapshotOutput } from '@direct
 import type { DirectusError } from '../../types/extension';
 import type { Schema } from '../api';
 import { schemaApply, schemaDiff } from '@directus/sdk';
+import { filterSchemaDiff, getCollectionsFromSchema } from '../../utils/filter-schema-diff';
 
 export async function migrateSchema({ res, client, schema, dry_run = false, force = false }: { res: any; client: RestClient<Schema>; schema: SchemaSnapshotOutput; dry_run: boolean; force: boolean }): Promise<SchemaDiffOutput | DirectusError> {
 	try {
+		// Get collections from the filtered schema for diff filtering
+		const schemaCollections = getCollectionsFromSchema(schema);
+
+		// Debug: Log schema being sent (using res.write so it appears in output)
+		res.write(`[DEBUG] Sending schema with ${schemaCollections.size} collections: ${Array.from(schemaCollections).join(', ')}\r\n`);
+		res.write(`[DEBUG] Schema fields count: ${(schema as any).fields?.length || 0}\r\n`);
+		res.write(`[DEBUG] Schema relations count: ${(schema as any).relations?.length || 0}\r\n\r\n`);
+
 		res.write('1. Comparing Schemas ...');
 
-		const diff: SchemaDiffOutput = force
+		const rawDiff: SchemaDiffOutput = force
 			? await client.request(() => ({
 				body: JSON.stringify(schema),
 				method: 'POST',
@@ -15,27 +24,55 @@ export async function migrateSchema({ res, client, schema, dry_run = false, forc
 			}))
 			: await client.request(schemaDiff(schema));
 
+		// Filter the diff to exclude directus_* collections
+		const diff = filterSchemaDiff(rawDiff, schemaCollections);
+
+		// Debug: Log diff info BEFORE filtering
+		if ('diff' in rawDiff && rawDiff.diff) {
+			const rawCollections = rawDiff.diff.collections?.map((c: any) => c.collection) || [];
+			res.write(`[DEBUG] RAW diff collections (${rawCollections.length}): ${rawCollections.join(', ')}\r\n`);
+		}
+
+		// Debug: Log diff info AFTER filtering
+		if ('diff' in diff && diff.diff) {
+			const filteredCollections = diff.diff.collections?.map((c: any) => c.collection) || [];
+			const diffFields = diff.diff.fields?.length || 0;
+			const diffRelations = diff.diff.relations?.length || 0;
+			res.write(`[DEBUG] FILTERED diff collections (${filteredCollections.length}): ${filteredCollections.join(', ')}\r\n`);
+			res.write(`[DEBUG] FILTERED diff: ${filteredCollections.length} collections, ${diffFields} fields, ${diffRelations} relations\r\n`);
+		}
+
 		if (!('hash' in diff)) {
 			res.write('match\r\n\r\n');
 		}
 		else {
-			res.write('done\r\n\r\n');
+			// Check if filtered diff has any changes
+			const hasChanges = (diff.diff?.collections?.length || 0) > 0 ||
+				(diff.diff?.fields?.length || 0) > 0 ||
+				(diff.diff?.relations?.length || 0) > 0;
 
-			res.write('2. Applying Schemas ...');
-
-			if (!dry_run) {
-				await (!force
-					? client.request(schemaApply(diff))
-					: client.request(() => ({
-							body: JSON.stringify(diff),
-							method: 'POST',
-							path: '/schema/apply?force=true',
-						})));
-
-				res.write('done\r\n\r\n');
+			if (!hasChanges) {
+				res.write('match (after filtering)\r\n\r\n');
 			}
 			else {
-				res.write('skipped\r\n\r\n');
+				res.write('done\r\n\r\n');
+
+				res.write('2. Applying Schemas ...');
+
+				if (!dry_run) {
+					await (!force
+						? client.request(schemaApply(diff))
+						: client.request(() => ({
+								body: JSON.stringify(diff),
+								method: 'POST',
+								path: '/schema/apply?force=true',
+							})));
+
+					res.write('done\r\n\r\n');
+				}
+				else {
+					res.write('skipped\r\n\r\n');
+				}
 			}
 		}
 

--- a/packages/migration-bundle/src/migration-endpoint/index.ts
+++ b/packages/migration-bundle/src/migration-endpoint/index.ts
@@ -4,6 +4,7 @@ import { ForbiddenError } from '@directus/errors';
 import { defineEndpoint } from '@directus/extensions-sdk';
 import { createDirectus, rest, staticToken } from '@directus/sdk';
 import { toArray } from '@directus/utils';
+import { filterSchema } from '../utils/filter-schema';
 import notifyUser from '../utils/notify-user';
 import saveToFile from '../utils/save-file';
 import { validate_data, validate_migration, validate_system } from '../utils/validate';
@@ -61,6 +62,13 @@ export default defineEndpoint({
 					token: env.MIGRATION_BUNDLE_DEFAULT_TOKEN || '',
 					options: env.MIGRATION_BUNDLE_DEFAULT_OPTIONS
 						? String(env.MIGRATION_BUNDLE_DEFAULT_OPTIONS).split(',').map((s: string) => s.trim())
+						: [],
+					// Collection-level filtering from environment variables
+					selectedCollections: env.MIGRATION_BUNDLE_SELECTED_COLLECTIONS
+						? String(env.MIGRATION_BUNDLE_SELECTED_COLLECTIONS).split(',').map((s: string) => s.trim())
+						: [],
+					excludedCollections: env.MIGRATION_BUNDLE_EXCLUDED_COLLECTIONS
+						? String(env.MIGRATION_BUNDLE_EXCLUDED_COLLECTIONS).split(',').map((s: string) => s.trim())
 						: [],
 				};
 				res.json(defaults);
@@ -248,7 +256,9 @@ export default defineEndpoint({
 				try {
 					// Step 1.1: Schema
 					res.write(`<div class="pending"><h3>${spinner} Creating Schema Snapshot</h3>\r\n\r\n`);
-					const currentSchema = await schemaService.snapshot();
+					const fullSchema = await schemaService.snapshot();
+					// Apply collection filtering to schema if specified
+					const currentSchema = scope.schema ? filterSchema(fullSchema, scope) : fullSchema;
 					await saveToFile(currentSchema, 'schema', fileService, folder, storage);
 					res.write(`</div><h3 class="done">${Icon} Schema Snapshot Created</h3>\r\n\r\n`);
 
@@ -289,19 +299,30 @@ export default defineEndpoint({
 
 					// Step 2: Migration
 					res.write(isDryRun ? '## Checking Destination\r\n\r\n' : '## Starting Migration\r\n\r\n');
-					// Step 2.1 Schema
-					res.write(`<div class="pending"><h3>${spinner} Applying Schema</h3>\r\n\r\n`);
-					const response = await migrateSchema({ res, client, schema: currentSchema, dry_run: isDryRun, force: scope.force }); // Can be { status: 204 } if there is no change
 
-					if ('errors' in response) {
-						const message = Array.isArray(response.errors) && response.errors.length > 0 ? response.errors[0]?.message : 'Unknown';
-						await notifyUser(notificationService, accountability, response);
-						res.write(`</div><h3 class="error">${Icon} Schema Failed to Apply</h3>\r\n\r\n`);
-						res.write(`Error Occurred: ${message}\r\n\r\n`);
+					// Step 2.1 Schema (conditional)
+					let schemaMigrationOk = true;
+					if (scope.schema) {
+						res.write(`<div class="pending"><h3>${spinner} Applying Schema</h3>\r\n\r\n`);
+						const response = await migrateSchema({ res, client, schema: currentSchema, dry_run: isDryRun, force: scope.force }); // Can be { status: 204 } if there is no change
+
+						if ('errors' in response) {
+							const message = Array.isArray(response.errors) && response.errors.length > 0 ? response.errors[0]?.message : 'Unknown';
+							await notifyUser(notificationService, accountability, response);
+							res.write(`</div><h3 class="error">${Icon} Schema Failed to Apply</h3>\r\n\r\n`);
+							res.write(`Error Occurred: ${message}\r\n\r\n`);
+							schemaMigrationOk = false;
+						}
+						else {
+							res.write(`</div><h3 class="done">${Icon} Schema Applied</h3>\r\n\r\n`);
+						}
 					}
 					else {
-						res.write(`</div><h3 class="done">${Icon} Schema Applied</h3>\r\n\r\n`);
+						res.write(`<h3 class="skipped">${Icon} Schema Skipped</h3>\r\n\r\n`);
+					}
 
+					// Continue with other migrations if schema succeeded or was skipped
+					if (schemaMigrationOk) {
 						// Step 2.2: Users
 						if (scope.users) {
 							res.write(`<div class="pending"><h3>${spinner} Migrating Users</h3>\r\n\r\n`);
@@ -430,7 +451,7 @@ export default defineEndpoint({
 						else {
 							res.write(`<h3 class="skipped">${Icon} Extensions Skipped</h3>\r\n\r\n`);
 						}
-					}
+					} // End of schemaMigrationOk block
 
 					res.write(`## Migration ${isDryRun ? 'Dry Run' : ''} Complete\r\n\r\n`);
 					res.write(`The files can be download from the [file library](/admin/files/folders/${folder}).\r\n\r\n`);

--- a/packages/migration-bundle/src/migration-module/module.vue
+++ b/packages/migration-bundle/src/migration-module/module.vue
@@ -2,11 +2,11 @@
 import type { AxiosProgressEvent } from 'axios';
 import type { Payload } from '../types/extension';
 import { useApi } from '@directus/extensions-sdk';
-import { defineComponent, reactive, ref, watch } from 'vue';
+import { computed, defineComponent, reactive, ref, watch } from 'vue';
 import { md } from '../utils/md';
 import SupportNavigation from './components/navigation.vue';
 
-type Options = 'content' | 'users' | 'comments' | 'presets' | 'dashboards' | 'extensions' | 'flows' | 'force';
+type Options = 'schema' | 'content' | 'users' | 'comments' | 'presets' | 'dashboards' | 'extensions' | 'flows' | 'force';
 
 export default defineComponent({
 	components: {
@@ -39,10 +39,21 @@ export default defineComponent({
 			options: [],
 		});
 
+		// Collection-level filtering
+		const availableCollections = ref<{ label: string; value: string }[]>([]);
+		const selectedCollections = ref<string[]>([]);
+		const excludedCollections = ref<string[]>([]);
+		const collectionFilterMode = ref<'all' | 'include' | 'exclude'>('all');
+		const isLoadingCollections = ref<boolean>(false);
+
 		const migrationOptions = ref<{
 			label: string;
 			value: string;
 		}[]>([
+			{
+				label: 'Schema',
+				value: 'schema',
+			},
 			{
 				label: 'Content',
 				value: 'content',
@@ -75,7 +86,8 @@ export default defineComponent({
 
 		const migrationOptionsSelections = ref<Options[] | null>(migrationOptions.value.map((o) => o.value as Options));
 
-		const scope = reactive<Record<Options, boolean>>({
+		const scope = reactive<Record<Options, boolean> & { selectedCollections?: string[]; excludedCollections?: string[]; contentCollections?: string[] }>({
+			schema: true,
 			users: false,
 			content: false,
 			comments: false,
@@ -86,7 +98,55 @@ export default defineComponent({
 			force: false,
 		});
 
+		// Content-specific collection selection (subset of schema-selected collections)
+		const contentCollections = ref<string[]>([]);
+
+		// Fix 6.1: Show Force checkbox when partial migration is selected
+		const allMigrationOptions = ['schema', 'content', 'users', 'comments', 'presets', 'dashboards', 'extensions', 'flows'];
+		const showForceCheckbox = computed(() => {
+			// Show if compatibility check suggests force
+			const forceInMessage = validationMessage.value?.message?.includes('force') || false;
+
+			// Show if partial migration (not all options selected)
+			const partialMigration = !migrationOptionsSelections.value ||
+				migrationOptionsSelections.value.length < allMigrationOptions.length;
+
+			return forceInMessage || partialMigration;
+		});
+
 		const api = useApi();
+
+		// Fix 3.3: Sync contentCollections with selectedCollections
+		// When user selects collections for schema, auto-select them for content too
+		watch(selectedCollections, (newValue) => {
+			if (newValue && newValue.length > 0) {
+				// Auto-sync: content collections = schema selected collections
+				contentCollections.value = [...newValue];
+			}
+		}, { immediate: true });
+
+		// Load available collections from Directus
+		const loadCollections = async () => {
+			isLoadingCollections.value = true;
+			try {
+				const response = await api.get('/collections');
+				const collections = response.data.data || [];
+				availableCollections.value = collections
+					.filter((c: any) => !c.collection.startsWith('directus_'))
+					.filter((c: any) => c.schema !== null)
+					.map((c: any) => ({
+						label: c.meta?.translations?.[0]?.translation || c.collection,
+						value: c.collection,
+					}))
+					.sort((a: any, b: any) => a.label.localeCompare(b.label));
+			}
+			catch (error) {
+				console.error('Failed to load collections:', error);
+			}
+			finally {
+				isLoadingCollections.value = false;
+			}
+		};
 
 		// Load ENV defaults
 		const loadEnvDefaults = async () => {
@@ -98,9 +158,24 @@ export default defineComponent({
 				if (defaults.token) token.value = defaults.token;
 
 				if (defaults.options && defaults.options.length > 0) {
-					migrationOptionsSelections.value = defaults.options.filter((opt: string) =>
+					let options = defaults.options.filter((opt: string) =>
 						migrationOptions.value.some((o) => o.value === opt),
 					) as Options[];
+					// Fix 3.2: Ensure 'schema' is always included in options
+					if (!options.includes('schema')) {
+						options = ['schema', ...options];
+					}
+					migrationOptionsSelections.value = options;
+				}
+
+				// Load collection-level filtering from ENV
+				if (defaults.selectedCollections && defaults.selectedCollections.length > 0) {
+					selectedCollections.value = defaults.selectedCollections;
+					collectionFilterMode.value = 'include';
+				}
+				else if (defaults.excludedCollections && defaults.excludedCollections.length > 0) {
+					excludedCollections.value = defaults.excludedCollections;
+					collectionFilterMode.value = 'exclude';
 				}
 			}
 			catch {
@@ -136,7 +211,12 @@ export default defineComponent({
 					: preset.layout_options;
 				baseURL.value = options.baseURL || '';
 				token.value = options.token || '';
-				migrationOptionsSelections.value = options.selectedOptions || [];
+				// Fix 3.2: Ensure 'schema' is always included in preset options
+				let selectedOptions = options.selectedOptions || [];
+				if (!selectedOptions.includes('schema')) {
+					selectedOptions = ['schema', ...selectedOptions];
+				}
+				migrationOptionsSelections.value = selectedOptions;
 
 				// Store original config
 				originalConfig.value = {
@@ -211,6 +291,9 @@ export default defineComponent({
 		// Initialize on mount
 		const initialize = async () => {
 			isLoadingConfig.value = true;
+
+			// Load available collections for filtering
+			await loadCollections();
 
 			// Load presets first
 			await loadPresets();
@@ -318,6 +401,28 @@ export default defineComponent({
 
 			scope.force = forceSchema.value;
 
+			// Add collection-level filtering to scope
+			if (collectionFilterMode.value === 'include' && selectedCollections.value.length > 0) {
+				scope.selectedCollections = selectedCollections.value;
+				delete scope.excludedCollections;
+			}
+			else if (collectionFilterMode.value === 'exclude' && excludedCollections.value.length > 0) {
+				scope.excludedCollections = excludedCollections.value;
+				delete scope.selectedCollections;
+			}
+			else {
+				delete scope.selectedCollections;
+				delete scope.excludedCollections;
+			}
+
+			// Add content-specific collection selection
+			if (contentCollections.value.length > 0) {
+				scope.contentCollections = contentCollections.value;
+			}
+			else {
+				delete scope.contentCollections;
+			}
+
 			response.value = await api.post(`/migration/${dryRun ? 'dry-run' : 'run'}`, { baseURL, token, scope }, {
 				onDownloadProgress: (progressEvent: AxiosProgressEvent) => {
 					let eventObj: XMLHttpRequest | undefined;
@@ -373,6 +478,15 @@ export default defineComponent({
 			confirmDelete,
 			hasChanges,
 			updatePreset,
+			// Collection-level filtering
+			availableCollections,
+			selectedCollections,
+			excludedCollections,
+			collectionFilterMode,
+			isLoadingCollections,
+			contentCollections,
+			// Fix 6.1: Force checkbox visibility
+			showForceCheckbox,
 		};
 	},
 });
@@ -462,14 +576,20 @@ export default defineComponent({
 						<v-notice :icon="validationMessage.icon" :type="validationMessage.status">
 							{{ validationMessage.message }}
 						</v-notice>
+					</div>
+
+					<!-- Fix 6.1: Force checkbox - visible for partial migrations -->
+					<div v-if="showForceCheckbox && validationMessage" class="migration-force-option">
 						<v-checkbox
-							v-if="validationMessage.message.includes('force')"
 							v-model="forceSchema"
 							label="Force"
 							:disabled="lockInterface"
 						>
 							Force
 						</v-checkbox>
+						<p v-if="!validationMessage.message.includes('force')" class="force-hint">
+							Enable Force mode for partial migrations to apply correctly.
+						</p>
 					</div>
 
 					<div v-if="forceSchema || (validationMessage && validationMessage.status === 'success')" class="migration-start">
@@ -502,6 +622,82 @@ export default defineComponent({
 						<v-button :disabled="lockInterface" @click="extractSchema({ baseURL, token, dryRun })">
 							Start
 						</v-button>
+					</div>
+
+					<!-- Collection-level filtering (shown when Schema OR Content is selected) -->
+					<div v-if="(forceSchema || (validationMessage && validationMessage.status === 'success')) && (migrationOptionsSelections?.includes('schema') || migrationOptionsSelections?.includes('content'))" class="migration-collection-filter">
+						<div class="collection-filter-header">
+							<v-icon name="filter_list" />
+							<span>Schema Collection Filter</span>
+							<v-select
+								v-model="collectionFilterMode"
+								:items="[
+									{ text: 'All Collections', value: 'all' },
+									{ text: 'Include Only', value: 'include' },
+									{ text: 'Exclude', value: 'exclude' },
+								]"
+								:disabled="lockInterface || isLoadingCollections"
+								placeholder="Filter Mode"
+							/>
+						</div>
+						<div v-if="collectionFilterMode === 'include'" class="collection-select">
+							<v-select
+								v-model="selectedCollections"
+								:items="availableCollections"
+								:disabled="lockInterface || isLoadingCollections"
+								:loading="isLoadingCollections"
+								:multiple-preview-threshold="2"
+								item-text="label"
+								item-value="value"
+								placeholder="Select collections for schema migration..."
+								multiple
+							>
+								<template #prepend>
+									<v-icon name="add_circle" />
+								</template>
+							</v-select>
+						</div>
+						<div v-if="collectionFilterMode === 'exclude'" class="collection-select">
+							<v-select
+								v-model="excludedCollections"
+								:items="availableCollections"
+								:disabled="lockInterface || isLoadingCollections"
+								:loading="isLoadingCollections"
+								:multiple-preview-threshold="2"
+								item-text="label"
+								item-value="value"
+								placeholder="Select collections to exclude..."
+								multiple
+							>
+								<template #prepend>
+									<v-icon name="remove_circle" />
+								</template>
+							</v-select>
+						</div>
+
+						<!-- Content collection selection (only when Content is selected AND collections are filtered) -->
+						<div v-if="migrationOptionsSelections?.includes('content') && collectionFilterMode === 'include' && selectedCollections.length > 0" class="content-collection-select">
+							<div class="collection-filter-header">
+								<v-icon name="storage" />
+								<span>Content Data Selection</span>
+							</div>
+							<v-select
+								v-model="contentCollections"
+								:items="availableCollections.filter(c => selectedCollections.includes(c.value))"
+								:disabled="lockInterface || isLoadingCollections"
+								:loading="isLoadingCollections"
+								:multiple-preview-threshold="2"
+								item-text="label"
+								item-value="value"
+								placeholder="Select which collections should have data migrated..."
+								multiple
+							>
+								<template #prepend>
+									<v-icon name="table_rows" />
+								</template>
+							</v-select>
+							<p class="content-hint">Only data from selected collections will be migrated. Leave empty to migrate all schema-selected collections' data.</p>
+						</div>
 					</div>
 				</div>
 
@@ -863,5 +1059,54 @@ h3.skipped .icon i::after {
 .migration-preset-selector.has-changes .preset-row {
 	border-color: var(--theme--primary);
 	box-shadow: 0 0 0 1px var(--theme--primary-background);
+}
+
+/* Collection-level filtering styles */
+.migration-collection-filter {
+	margin-top: 20px;
+	padding: var(--theme--form--field--input--padding);
+	background-color: var(--theme--background-normal);
+	border-radius: var(--theme--border-radius);
+}
+
+.collection-filter-header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-bottom: 12px;
+}
+
+.collection-filter-header span {
+	flex-grow: 1;
+	font-weight: 600;
+}
+
+.collection-filter-header .v-select {
+	max-width: 180px;
+}
+
+.collection-select {
+	margin-top: 8px;
+}
+
+.collection-select .v-select {
+	width: 100%;
+}
+
+.content-collection-select {
+	margin-top: 16px;
+	padding-top: 16px;
+	border-top: 1px solid var(--theme--border-color);
+}
+
+.content-collection-select .v-select {
+	width: 100%;
+	margin-top: 8px;
+}
+
+.content-hint {
+	margin-top: 8px;
+	font-size: 12px;
+	color: var(--theme--foreground-subdued);
 }
 </style>

--- a/packages/migration-bundle/src/types/extension.ts
+++ b/packages/migration-bundle/src/types/extension.ts
@@ -172,6 +172,7 @@ export interface Translation {
 }
 
 export interface Scope {
+	schema: boolean;
 	users: boolean;
 	content: boolean;
 	comments: boolean;
@@ -180,6 +181,11 @@ export interface Scope {
 	extensions: boolean;
 	flows: boolean;
 	force: boolean;
+	// Collection-level filtering
+	selectedCollections?: string[];
+	excludedCollections?: string[];
+	// Content-specific collection selection (subset of selectedCollections)
+	contentCollections?: string[];
 }
 
 ;

--- a/packages/migration-bundle/src/utils/filter-schema-diff.ts
+++ b/packages/migration-bundle/src/utils/filter-schema-diff.ts
@@ -1,0 +1,72 @@
+import type { SchemaDiffOutput } from '@directus/sdk';
+
+/**
+ * Filters a schema diff to exclude directus_* system collections
+ * and optionally limit to specific collections.
+ */
+export function filterSchemaDiff(
+	diff: SchemaDiffOutput,
+	includedCollections?: Set<string>
+): SchemaDiffOutput {
+	// If no diff or no hash (meaning no changes), return as-is
+	if (!diff || !('hash' in diff) || !('diff' in diff)) {
+		return diff;
+	}
+
+	const shouldInclude = (collectionName: string): boolean => {
+		// Always exclude directus_* system collections
+		if (collectionName.startsWith('directus_')) {
+			return false;
+		}
+		// If we have a specific set of collections to include, check against it
+		if (includedCollections && includedCollections.size > 0) {
+			return includedCollections.has(collectionName);
+		}
+		// Otherwise include all non-system collections
+		return true;
+	};
+
+	const filteredDiff = { ...diff.diff };
+
+	// Filter collections
+	if (filteredDiff.collections && Array.isArray(filteredDiff.collections)) {
+		filteredDiff.collections = filteredDiff.collections.filter((c: any) =>
+			shouldInclude(c.collection)
+		);
+	}
+
+	// Filter fields
+	if (filteredDiff.fields && Array.isArray(filteredDiff.fields)) {
+		filteredDiff.fields = filteredDiff.fields.filter((f: any) =>
+			shouldInclude(f.collection)
+		);
+	}
+
+	// Filter relations
+	if (filteredDiff.relations && Array.isArray(filteredDiff.relations)) {
+		filteredDiff.relations = filteredDiff.relations.filter((r: any) =>
+			shouldInclude(r.collection) &&
+			(r.related_collection === null || shouldInclude(r.related_collection))
+		);
+	}
+
+	return {
+		...diff,
+		diff: filteredDiff,
+	};
+}
+
+/**
+ * Extracts the set of collection names from a schema snapshot
+ */
+export function getCollectionsFromSchema(schema: any): Set<string> {
+	const collections = new Set<string>();
+	if (schema?.collections && Array.isArray(schema.collections)) {
+		for (const c of schema.collections) {
+			if (c.collection && !c.collection.startsWith('directus_')) {
+				collections.add(c.collection);
+			}
+		}
+	}
+	return collections;
+}

--- a/packages/migration-bundle/src/utils/filter-schema.ts
+++ b/packages/migration-bundle/src/utils/filter-schema.ts
@@ -1,0 +1,103 @@
+import type { Snapshot } from '@directus/types';
+import type { Scope } from '../types/extension';
+
+export function filterSchema(schema: Snapshot, scope: Scope): Snapshot {
+	const { selectedCollections, excludedCollections } = scope;
+
+	// Use process.stdout.write for logging (more reliable than console.log in some contexts)
+	const log = (msg: string) => {
+		try {
+			process.stdout.write(`[filter-schema] ${msg}\n`);
+		} catch {
+			// Fallback to console.log if process.stdout is not available
+			console.log(`[filter-schema] ${msg}`);
+		}
+	};
+
+	log(`Input collections count: ${schema.collections?.length || 0}`);
+	log(`Selected collections: ${JSON.stringify(selectedCollections || [])}`);
+	log(`Excluded collections: ${JSON.stringify(excludedCollections || [])}`);
+
+	// If no filtering specified, return full schema
+	if ((!selectedCollections || selectedCollections.length === 0) &&
+		(!excludedCollections || excludedCollections.length === 0)) {
+		log('No filtering specified, returning full schema');
+		return schema;
+	}
+
+	// Build initial set of included collections
+	const includedCollections = new Set<string>();
+
+	if (selectedCollections && selectedCollections.length > 0) {
+		// Include mode: start with selected collections
+		for (const collectionName of selectedCollections) {
+			// Skip directus_* system collections - they should not be in filtered schema
+			if (!collectionName.startsWith('directus_')) {
+				includedCollections.add(collectionName);
+			}
+		}
+	} else if (excludedCollections && excludedCollections.length > 0) {
+		// Exclude mode: start with all non-system collections, remove excluded
+		for (const c of schema.collections) {
+			if (!c.collection.startsWith('directus_') && !excludedCollections.includes(c.collection)) {
+				includedCollections.add(c.collection);
+			}
+		}
+	}
+
+	log(`Initial included collections (before group resolution): ${Array.from(includedCollections).join(', ')}`);
+
+	// Recursively add parent groups
+	// Collections can have a 'group' property in their meta that references a parent collection
+	let changed = true;
+	let iterations = 0;
+	const maxIterations = 100; // Safety limit
+
+	while (changed && iterations < maxIterations) {
+		changed = false;
+		iterations++;
+
+		for (const c of schema.collections) {
+			// If this collection is included and has a parent group
+			if (includedCollections.has(c.collection)) {
+				const parentGroup = (c as any).meta?.group;
+				if (parentGroup && !parentGroup.startsWith('directus_') && !includedCollections.has(parentGroup)) {
+					log(`Adding parent group '${parentGroup}' for collection '${c.collection}'`);
+					includedCollections.add(parentGroup);
+					changed = true;
+				}
+			}
+		}
+	}
+
+	if (iterations >= maxIterations) {
+		log('WARNING: Max iterations reached while resolving parent groups');
+	}
+
+	log(`Final included collections (after group resolution): ${Array.from(includedCollections).join(', ')}`);
+
+	// Filter function
+	const shouldInclude = (collectionName: string): boolean => {
+		// Always exclude directus_* system collections from filtered schema
+		if (collectionName.startsWith('directus_')) {
+			return false;
+		}
+		return includedCollections.has(collectionName);
+	};
+
+	const result: Snapshot = {
+		version: schema.version,
+		directus: schema.directus,
+		vendor: schema.vendor,
+		collections: schema.collections.filter(c => shouldInclude(c.collection)),
+		fields: schema.fields.filter(f => shouldInclude(f.collection)),
+		relations: schema.relations.filter(r =>
+			shouldInclude(r.collection) &&
+			(r.related_collection === null || shouldInclude(r.related_collection))
+		),
+	};
+
+	log(`Output: ${result.collections.length} collections, ${result.fields.length} fields, ${result.relations.length} relations`);
+
+	return result;
+}


### PR DESCRIPTION
## Summary

This PR adds collection-level selection functionality to the migration-bundle extension, allowing users to select specific collections to migrate instead of migrating all content at once.

**Addresses:** #266, #294

### Features Added

- **Collection-Level Selection:** Users can now select specific collections for schema and content migration
- **File Filtering:** Only files referenced by selected collections are migrated
- **Parent Group Auto-Inclusion:** When child collections are selected, parent group collections are automatically included
- **Schema Option:** Added "Schema" as a selectable migration option (previously always migrated)
- **Filtered System Data:** Panels, flows, presets, and comments are now filtered based on collection references
- **Environment Variables:**
  - `MIGRATION_BUNDLE_SELECTED_COLLECTIONS`
  - `MIGRATION_BUNDLE_EXCLUDED_COLLECTIONS`

### Important Note: PostgreSQL Requirement

Due to a known Directus bug ([#20428](https://github.com/directus/directus/issues/20428)), schema migrations may fail on MySQL target instances. The bug causes `char(36)` to `varchar(36)` conversion which breaks MySQL foreign key constraints.

**Recommendation:** Use PostgreSQL for the target instance.

| Target Database | Schema Migration | Status |
|-----------------|------------------|--------|
| PostgreSQL | ✅ Works correctly | Recommended |
| MySQL | ⚠️ May fail with FK errors | Known issue |

## Test Plan

- [ ] Test migration with specific collections selected (schema + content)
- [ ] Verify parent group collections are auto-included
- [ ] Test file filtering with selected collections
- [ ] Verify panels/flows/presets are filtered by collection
- [ ] Test with PostgreSQL target instance

> **Development Note:** This feature was developed with assistance from Claude Code (Anthropic's AI coding assistant).

🤖 Generated with [Claude Code](https://claude.ai/code)