### PR TITLE
feat(migration-bundle): granular migration options with tab-based UI

### DIFF
--- a/packages/migration-bundle/CHANGELOG.md
+++ b/packages/migration-bundle/CHANGELOG.md
@@ -1,5 +1,75 @@
 # Changelog
 
+## 1.3.0 - 2026-03-02
+
+> **Development Note:** This release was developed with assistance from Claude Code (Anthropic's AI coding assistant).
+
+### Features
+
+- **Tab-Based UI Redesign:** Complete redesign of the Migration Options interface with organized tabs for each category (Schema, Content, Files, Users, Flows, Extensions, Settings, Translations, Bookmarks, Insights). Addresses [Issue #294](https://github.com/directus-labs/extensions/issues/294).
+
+- **Users Granular Filtering:** Fine-grained control over user-related migrations:
+  - Roles filtering with `selectedRoles`
+  - Policies filtering with `selectedPolicies`
+  - Permissions filtering with `selectedPermissions`
+  - User accounts filtering with `selectedUsers`
+  - Access rules filtering with `selectedAccess`
+  - Dependency auto-selection (selecting a user auto-selects their role)
+
+- **Flows Granular Filtering:** Select specific flows to migrate using `selectedFlows`. Supports both flow ID (UUID) and flow name for flexible filtering.
+
+- **Extensions Granular Filtering:** Select specific extensions to migrate using `selectedExtensions`. Supports ID, schema name, and bundle name matching.
+
+- **Files/Folders Filtering:** New Files tab with folder-based filtering using `selectedFolders`. Migrate only files from selected folders.
+
+- **Settings Granular Filtering:** Select specific settings fields to migrate instead of all settings.
+
+- **Translations Granular Filtering:** Filter translations by:
+  - Selected languages with `selectedLanguages`
+  - Key pattern matching with `translationKeyPattern`
+
+- **Bookmarks Tab:** New dedicated tab for bookmark (preset) management with `selectedPresets` filtering.
+
+- **Insights Tab:** New dedicated tab for dashboard management with `selectedDashboards` filtering.
+
+- **Comments Integration:** Comments can now be migrated independently or tied to content collections using `includeCommentsForContent`.
+
+- **GUI Collection Context Filtering:** Bookmarks and Flows lists automatically filter based on selected schema collections, showing only relevant items.
+
+- **Local Extensions Warning:** UI notice when local extensions are detected, informing users they must be manually installed on the target.
+
+### Bug Fixes
+
+- **Tab Visibility Bug:** Fixed tabs permanently disappearing after deselecting all items. Root cause was Directus v-select returning `null` instead of `[]`.
+- **selectedExtensions Filter:** Now accepts both extension ID and schema.name for matching.
+- **Empty usersSelection Skip:** Migration now correctly skips empty user selection objects.
+- **Null Collection Handling:** Fixed include/exclude modes to properly handle items with null collection references.
+- **Comments Migration:** Moved comments migration outside content block to allow independent migration.
+
+### Environment Variables
+
+New environment variables for granular control:
+
+```bash
+# Flows filtering (ID or name, comma-separated)
+MIGRATION_BUNDLE_SELECTED_FLOWS=flow-uuid,My Flow Name
+
+# Extensions filtering
+MIGRATION_BUNDLE_SELECTED_EXTENSIONS=@directus-labs/field-comments
+
+# Folders filtering
+MIGRATION_BUNDLE_SELECTED_FOLDERS=folder-uuid-1,folder-uuid-2
+
+# Users granular options
+MIGRATION_BUNDLE_USERS_ROLES=true
+MIGRATION_BUNDLE_USERS_POLICIES=true
+MIGRATION_BUNDLE_USERS_PERMISSIONS=true
+MIGRATION_BUNDLE_USERS_ACCOUNTS=true
+MIGRATION_BUNDLE_USERS_ACCESS=true
+```
+
+---
+
 ## 1.2.0 - 2026-02-24
 
 > **Development Note:** This release was developed with assistance from Claude Code (Anthropic's AI coding assistant).

--- a/packages/migration-bundle/CHANGELOG.md
+++ b/packages/migration-bundle/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+## 1.2.0 - 2026-02-24
+
+> **Development Note:** This release was developed with assistance from Claude Code (Anthropic's AI coding assistant).
+
+### Features
+
+- **Collection-Level Selection:** Users can now select specific collections to migrate instead of migrating all content at once. This feature addresses [Issue #266](https://github.com/directus-labs/extensions/issues/266) and [Issue #294](https://github.com/directus-labs/extensions/issues/294).
+  - Schema filtering: Only selected collections' schemas are migrated
+  - Content filtering: Only selected collections' data is migrated
+  - Parent group collections are automatically included when child collections are selected
+
+- **File Filtering by Collection:** Files are now filtered based on selected collections. Only files referenced by the selected collections are migrated, reducing migration payload size and improving performance.
+
+- **Content Collection Selector UI:** New multi-select interface in the Migration Options to choose which collections to migrate.
+
+- **Environment Variable Support:**
+  - `MIGRATION_BUNDLE_SELECTED_COLLECTIONS`: Comma-separated list of collections to include
+  - `MIGRATION_BUNDLE_EXCLUDED_COLLECTIONS`: Comma-separated list of collections to exclude
+
+### Improvements
+
+- **Schema Option Checkbox:** Added "Schema" as a selectable migration option (previously schema was always migrated)
+- **Filtered Panels/Flows/Presets:** Dashboard panels, flows, and presets are now filtered based on their collection references
+- **Debug Logging:** Added debug output during schema filtering for troubleshooting
+
+### Important Notes
+
+#### PostgreSQL Requirement for Target Instance
+
+Due to a known Directus bug ([GitHub Issue #20428](https://github.com/directus/directus/issues/20428)), schema migrations may fail on MySQL target instances. The issue occurs because Directus automatically converts `char(36)` to `varchar(36)` in schema diffs for PostgreSQL compatibility, which breaks MySQL foreign key constraints.
+
+**Recommendation:** Use PostgreSQL for the target (destination) Directus instance to ensure reliable schema migrations.
+
+| Target Database | Schema Apply | Status |
+|-----------------|--------------|--------|
+| PostgreSQL | Works correctly | ✅ Recommended |
+| MySQL | May fail with FK constraint errors | ⚠️ Known issue |
+
+### Internal Changes
+
+- Refactored `extract-data.ts` to filter collections list with parent group resolution
+- Added `filter-schema.ts` utility for schema snapshot filtering
+- Added `filter-schema-diff.ts` utility for diff response filtering
+- Modified `extract-system.ts` to filter panels, flows, presets, and comments by collection
+
+---
+
+## 1.1.1 - Previous Release
+
+- Initial release with category-level migration options
+- Support for migrating content, users, flows, dashboards, extensions, presets, and comments

--- a/packages/migration-bundle/README.md
+++ b/packages/migration-bundle/README.md
@@ -108,6 +108,55 @@ This approach provides:
 ![Customise the module](https://raw.githubusercontent.com/directus-labs/extensions/main/packages/migration-bundle/docs/migration-module-customize.jpg)
 
 
+## Collection-Level Selection
+
+> **New in v1.2.0** - Developed with assistance from Claude Code (Anthropic's AI coding assistant).
+
+You can now select specific collections to migrate instead of migrating all content at once. This feature is useful for:
+- Large schemas where only specific collections need synchronization
+- Reducing migration payload size
+- Partial content migrations between instances
+
+### How to Use Collection Filtering
+
+1. Configure your migration as usual (destination URL and token)
+2. Click **Check** to validate the connection
+3. In Migration Options, check **Schema** and/or **Content**
+4. A collection selector will appear - choose which collections to migrate
+5. Start the migration
+
+**Note:** When you select child collections, their parent group collections are automatically included to maintain schema integrity.
+
+### File Filtering
+
+Files are automatically filtered based on your collection selection. Only files that are referenced by the selected collections will be migrated, significantly reducing migration time for partial migrations.
+
+### Environment Variables for Collection Filtering
+
+```bash
+# Include only specific collections (comma-separated)
+MIGRATION_BUNDLE_SELECTED_COLLECTIONS=articles,authors,categories
+
+# Exclude specific collections (used if SELECTED is not set)
+MIGRATION_BUNDLE_EXCLUDED_COLLECTIONS=logs,temp_data,analytics
+```
+
+## Important: PostgreSQL Requirement for Target Instance
+
+Due to a known Directus bug ([GitHub Issue #20428](https://github.com/directus/directus/issues/20428)), schema migrations may fail on MySQL target instances.
+
+**Technical Details:**
+- Directus automatically converts `char(36)` to `varchar(36)` in schema diffs for PostgreSQL compatibility
+- This conversion triggers MySQL foreign key constraint errors: `Cannot change column 'X': used in a foreign key constraint`
+- The issue affects any migration that includes schema changes
+
+**Recommendation:** Use **PostgreSQL** for the target (destination) Directus instance to ensure reliable schema migrations.
+
+| Target Database | Schema Migration | Recommendation |
+|-----------------|------------------|----------------|
+| PostgreSQL | ✅ Works correctly | **Recommended** |
+| MySQL | ⚠️ May fail with FK errors | Use with caution |
+
 ## Permissions
 
-This extension requires admin privilages on both instances to ensure all data is accessible and writable.
+This extension requires admin privileges on both instances to ensure all data is accessible and writable.

--- a/packages/migration-bundle/README.md
+++ b/packages/migration-bundle/README.md
@@ -108,6 +108,57 @@ This approach provides:
 ![Customise the module](https://raw.githubusercontent.com/directus-labs/extensions/main/packages/migration-bundle/docs/migration-module-customize.jpg)
 
 
+## Granular Migration Options
+
+> **New in v1.3.0** - Developed with assistance from Claude Code (Anthropic's AI coding assistant).
+
+The migration module now features a **tab-based UI** with granular control over every aspect of your migration. Each category has its own dedicated tab with filtering options.
+
+### Available Tabs
+
+| Tab | Description | Filtering Options |
+|-----|-------------|-------------------|
+| **Schema** | Database schema | Include/exclude specific collections |
+| **Content** | Collection data | Select collections for content migration |
+| **Files** | Files and folders | Filter by specific folders |
+| **Users** | User management | Roles, policies, permissions, accounts, access rules |
+| **Flows** | Automation flows | Select specific flows by ID or name |
+| **Extensions** | Installed extensions | Select specific extensions |
+| **Settings** | Project settings | Select specific setting fields |
+| **Translations** | Custom translations | Filter by language and key pattern |
+| **Bookmarks** | User bookmarks | Select specific bookmarks |
+| **Insights** | Dashboards | Select specific dashboards |
+
+### Users Granular Options
+
+Control exactly which user-related data to migrate:
+
+- **Roles** - User roles and their configurations
+- **Policies** - Access policies
+- **Permissions** - Collection permissions
+- **User Accounts** - Actual user records
+- **Access Rules** - Role-policy-user mappings
+
+Dependencies are automatically handled - selecting a user will auto-select their assigned role.
+
+### Flows and Extensions Filtering
+
+You can filter flows and extensions by:
+- **ID (UUID)** - Exact match
+- **Name** - Human-readable name matching
+
+```bash
+# Environment variable examples
+MIGRATION_BUNDLE_SELECTED_FLOWS=abc-123-uuid,My Automation Flow
+MIGRATION_BUNDLE_SELECTED_EXTENSIONS=@directus-labs/field-comments,my-custom-extension
+```
+
+### Local Extensions Notice
+
+When local extensions are detected on the source instance, a warning notice appears informing you that these must be manually installed on the target instance before migration.
+
+---
+
 ## Collection-Level Selection
 
 > **New in v1.2.0** - Developed with assistance from Claude Code (Anthropic's AI coding assistant).

--- a/packages/migration-bundle/package.json
+++ b/packages/migration-bundle/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@directus-labs/migration-bundle",
 	"type": "module",
-	"version": "1.1.1",
+	"version": "1.2.0",
 	"description": "Migrate from the current source Directus instance to another target Directus instance.",
 	"license": "MIT",
 	"repository": {

--- a/packages/migration-bundle/package.json
+++ b/packages/migration-bundle/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@directus-labs/migration-bundle",
 	"type": "module",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"description": "Migrate from the current source Directus instance to another target Directus instance.",
 	"license": "MIT",
 	"repository": {

--- a/packages/migration-bundle/src/migration-endpoint/composables/extract-data.ts
+++ b/packages/migration-bundle/src/migration-endpoint/composables/extract-data.ts
@@ -34,30 +34,105 @@ async function extractContent({
 	try {
 		res.write('* Fetching collections');
 
-		const collections: Collection[] = await collectionService.readByQuery({
+		// Load all collections first
+		const allCollections: Collection[] = await collectionService.readByQuery({
 			limit: -1,
 		});
 
-		res.write(' ...done\r\n\r\n');
+		// Fix 8: Filter collections based on scope (same logic as fullData/singletons)
+		let collections = allCollections.filter(c => !c.collection.startsWith('directus_'));
+
+		const hasContentFilter = scope.contentCollections && scope.contentCollections.length > 0;
+		const hasSelectedFilter = scope.selectedCollections && scope.selectedCollections.length > 0;
+		const hasExcludedFilter = scope.excludedCollections && scope.excludedCollections.length > 0;
+
+		if (hasContentFilter || hasSelectedFilter) {
+			// Build initial set of included collection names
+			const selectedNames = hasContentFilter
+				? scope.contentCollections!
+				: scope.selectedCollections!;
+
+			const includedNames = new Set<string>(selectedNames);
+
+			// Recursively add parent groups (same logic as filter-schema.ts)
+			let changed = true;
+			let iterations = 0;
+			const maxIterations = 100;
+
+			while (changed && iterations < maxIterations) {
+				changed = false;
+				iterations++;
+				for (const c of allCollections) {
+					if (includedNames.has(c.collection) && c.meta?.group) {
+						if (!includedNames.has(c.meta.group)) {
+							includedNames.add(c.meta.group);
+							changed = true;
+						}
+					}
+				}
+			}
+
+			// Filter collections to only include selected + parent groups
+			collections = collections.filter(c => includedNames.has(c.collection));
+		}
+		else if (hasExcludedFilter) {
+			collections = collections.filter(c =>
+				!scope.excludedCollections!.includes(c.collection)
+			);
+		}
+
+		res.write(` (${collections.length} collections) ...done\r\n\r\n`);
 
 		res.write('* Fetching fields');
 		const primaryKeyMap = await getCollectionPrimaryKeys(fieldService);
 		res.write(' ...done\r\n\r\n');
 
 		res.write('* Fetching full data');
-		const fullData: UserCollectionItems[] = scope.content ? await loadFullData(collections, ItemsService, primaryKeyMap, accountability, schema) : [];
+		const fullData: UserCollectionItems[] = scope.content ? await loadFullData(collections, ItemsService, primaryKeyMap, accountability, schema, scope) : [];
 		res.write(' ...');
 		await saveToFile(fullData, 'items_full_data', fileService, folder, storage);
 		res.write('done\r\n\r\n');
 
 		res.write('* Fetching singletons');
-		const singletons: UserCollectionItem[] = scope.content ? await loadSingletons(collections, ItemsService, accountability, schema) : [];
+		const singletons: UserCollectionItem[] = scope.content ? await loadSingletons(collections, ItemsService, accountability, schema, scope) : [];
 		res.write(' ...');
 		await saveToFile(singletons, 'items_singleton', fileService, folder, storage);
 		res.write('done\r\n\r\n');
 
 		res.write('* Fetching files');
-		const files: File[] = scope.content ? await fileService.readByQuery({ fields: directusFileFields, filter: { _or: [{ folder: { _neq: folder } }, { folder: { _null: true } }] }, limit: -1 }) : [];
+		// Fix 6.3: Filter files based on selected collections
+		let files: File[] = [];
+		if (scope.content) {
+			const contentCols = scope.contentCollections?.length ? scope.contentCollections
+				: (scope.selectedCollections?.length ? scope.selectedCollections : null);
+
+			if (contentCols && contentCols.length > 0) {
+				// Get file IDs from selected collections
+				const fileIds = await getFileIdsFromCollections(contentCols, ItemsService, fieldService, accountability, schema);
+				res.write(` (${fileIds.size} files from ${contentCols.length} collections)`);
+
+				if (fileIds.size > 0) {
+					files = await fileService.readByQuery({
+						fields: directusFileFields,
+						filter: {
+							_and: [
+								{ id: { _in: Array.from(fileIds) } },
+								{ _or: [{ folder: { _neq: folder } }, { folder: { _null: true } }] },
+							],
+						},
+						limit: -1,
+					});
+				}
+			}
+			else {
+				// No filtering - get all files
+				files = await fileService.readByQuery({
+					fields: directusFileFields,
+					filter: { _or: [{ folder: { _neq: folder } }, { folder: { _null: true } }] },
+					limit: -1,
+				});
+			}
+		}
 		res.write(' ...');
 		await saveToFile(files, 'files', fileService, folder, storage);
 		res.write('done\r\n\r\n');
@@ -120,11 +195,25 @@ async function extractSingleton(collection: string, ItemsService: any, accountab
 	return await itemService.readSingleton({});
 }
 
-async function loadFullData(collections: Collection[], itemService: any, primaryKeyMap: any, accountability: Accountability, schema: SchemaOverview): Promise<UserCollectionItems[]> {
+async function loadFullData(collections: Collection[], itemService: any, primaryKeyMap: any, accountability: Accountability, schema: SchemaOverview, scope: Scope): Promise<UserCollectionItems[]> {
 	const userCollections = collections
 		.filter((item) => !item.collection.startsWith('directus_', 0))
 		.filter((item) => item.schema !== null)
-		.filter((item) => !item.meta?.singleton);
+		.filter((item) => !item.meta?.singleton)
+		// Collection-level filtering for content
+		// If contentCollections is specified, use that; otherwise fall back to selectedCollections/excludedCollections
+		.filter((item) => {
+			if (scope.contentCollections && scope.contentCollections.length > 0) {
+				return scope.contentCollections.includes(item.collection);
+			}
+			if (scope.selectedCollections && scope.selectedCollections.length > 0) {
+				return scope.selectedCollections.includes(item.collection);
+			}
+			if (scope.excludedCollections && scope.excludedCollections.length > 0) {
+				return !scope.excludedCollections.includes(item.collection);
+			}
+			return true;
+		});
 
 	return await Promise.all(userCollections.map(async (collection) => {
 		const name = collection.collection;
@@ -137,10 +226,24 @@ async function loadFullData(collections: Collection[], itemService: any, primary
 	}));
 }
 
-async function loadSingletons(collections: Collection[], itemService: any, accountability: Accountability, schema: SchemaOverview): Promise<UserCollectionItem[]> {
+async function loadSingletons(collections: Collection[], itemService: any, accountability: Accountability, schema: SchemaOverview, scope: Scope): Promise<UserCollectionItem[]> {
 	const singletonCollections = collections
 		.filter((item) => !item.collection.startsWith('directus_', 0))
-		.filter((item) => item.meta?.singleton);
+		.filter((item) => item.meta?.singleton)
+		// Collection-level filtering for content
+		// If contentCollections is specified, use that; otherwise fall back to selectedCollections/excludedCollections
+		.filter((item) => {
+			if (scope.contentCollections && scope.contentCollections.length > 0) {
+				return scope.contentCollections.includes(item.collection);
+			}
+			if (scope.selectedCollections && scope.selectedCollections.length > 0) {
+				return scope.selectedCollections.includes(item.collection);
+			}
+			if (scope.excludedCollections && scope.excludedCollections.length > 0) {
+				return !scope.excludedCollections.includes(item.collection);
+			}
+			return true;
+		});
 
 	return await Promise.all(singletonCollections.map(async (collection) => {
 		const name = collection.collection;
@@ -172,6 +275,60 @@ function getPrimaryKey(collectionsMap: any, collection: string) {
 	}
 
 	return collectionsMap[collection];
+}
+
+// Fix 6.3: Get file IDs from selected collections
+async function getFileIdsFromCollections(
+	collections: string[],
+	ItemsService: any,
+	fieldService: any,
+	accountability: Accountability,
+	schema: SchemaOverview,
+): Promise<Set<string>> {
+	const fileIds = new Set<string>();
+
+	// Get all fields to find file-type fields
+	const allFields = await fieldService.readAll();
+	if (!allFields) return fileIds;
+
+	// Find file-type fields in selected collections
+	const fileFields: Array<{ collection: string; field: string }> = [];
+	for (const field of allFields) {
+		if (!collections.includes(field.collection)) continue;
+
+		// Check for file field (uuid with file interface or special)
+		const isFileField = field.type === 'uuid' &&
+			(field.meta?.interface === 'file' ||
+				field.meta?.interface === 'file-image' ||
+				field.meta?.special?.includes('file'));
+
+		if (isFileField) {
+			fileFields.push({ collection: field.collection, field: field.field });
+		}
+	}
+
+	// Query each collection for file IDs
+	for (const { collection, field } of fileFields) {
+		try {
+			const itemService = new ItemsService(collection, { accountability, schema });
+			const items = await itemService.readByQuery({
+				fields: [field],
+				filter: { [field]: { _nnull: true } },
+				limit: -1,
+			});
+
+			for (const item of items) {
+				if (item[field]) {
+					fileIds.add(item[field]);
+				}
+			}
+		}
+		catch (error) {
+			console.error(`Failed to get files from ${collection}.${field}:`, error);
+		}
+	}
+
+	return fileIds;
 }
 
 export default extractContent;

--- a/packages/migration-bundle/src/migration-endpoint/composables/extract-data.ts
+++ b/packages/migration-bundle/src/migration-endpoint/composables/extract-data.ts
@@ -100,14 +100,21 @@ async function extractContent({
 		res.write('done\r\n\r\n');
 
 		// Files: fetch if files is selected, or content is selected (backward compatibility)
-		const shouldFetchFiles = scope.files === true || (scope.content && scope.files !== false);
+		// Issue #009: Skip if selectedFolders is an empty array (explicit skip)
+		const hasEmptyFolderSelection = Array.isArray(scope.selectedFolders) && scope.selectedFolders.length === 0;
+		const shouldFetchFiles = !hasEmptyFolderSelection && (scope.files === true || (scope.content && scope.files !== false));
 		res.write(shouldFetchFiles ? '* Fetching files' : '* Skipping files\r\n\r\n');
 
 		let files: File[] = [];
 		if (shouldFetchFiles) {
-			// Fix 6.3: Filter files based on selected collections when collection filtering is active
-			const contentCols = scope.contentCollections?.length ? scope.contentCollections
-				: (scope.selectedCollections?.length ? scope.selectedCollections : null);
+			// Fix 6.3: Filter files based on selectedCollections only (not contentCollections)
+			// contentCollections is for content-specific filtering, files should be independent
+			const contentCols = scope.selectedCollections?.length ? scope.selectedCollections : null;
+
+			// Issue #009: Build folder filter if selectedFolders is specified
+			const folderFilter = scope.selectedFolders && scope.selectedFolders.length > 0
+				? { folder: { _in: scope.selectedFolders } }
+				: { _or: [{ folder: { _neq: folder } }, { folder: { _null: true } }] };
 
 			if (contentCols && contentCols.length > 0) {
 				// Get file IDs from selected collections
@@ -120,7 +127,7 @@ async function extractContent({
 						filter: {
 							_and: [
 								{ id: { _in: Array.from(fileIds) } },
-								{ _or: [{ folder: { _neq: folder } }, { folder: { _null: true } }] },
+								folderFilter,
 							],
 						},
 						limit: -1,
@@ -128,12 +135,17 @@ async function extractContent({
 				}
 			}
 			else {
-				// No collection filtering - get all files
+				// No collection filtering - get all files (with optional folder filter)
 				files = await fileService.readByQuery({
 					fields: directusFileFields,
-					filter: { _or: [{ folder: { _neq: folder } }, { folder: { _null: true } }] },
+					filter: folderFilter,
 					limit: -1,
 				});
+			}
+
+			// Issue #009: Log folder filtering if active
+			if (scope.selectedFolders && scope.selectedFolders.length > 0) {
+				res.write(` (folder filter: ${scope.selectedFolders.length} folders)`);
 			}
 
 			res.write(' ...');

--- a/packages/migration-bundle/src/migration-endpoint/composables/extract-data.ts
+++ b/packages/migration-bundle/src/migration-endpoint/composables/extract-data.ts
@@ -99,10 +99,13 @@ async function extractContent({
 		await saveToFile(singletons, 'items_singleton', fileService, folder, storage);
 		res.write('done\r\n\r\n');
 
-		res.write('* Fetching files');
-		// Fix 6.3: Filter files based on selected collections
+		// Files: fetch if files is selected, or content is selected (backward compatibility)
+		const shouldFetchFiles = scope.files === true || (scope.content && scope.files !== false);
+		res.write(shouldFetchFiles ? '* Fetching files' : '* Skipping files\r\n\r\n');
+
 		let files: File[] = [];
-		if (scope.content) {
+		if (shouldFetchFiles) {
+			// Fix 6.3: Filter files based on selected collections when collection filtering is active
 			const contentCols = scope.contentCollections?.length ? scope.contentCollections
 				: (scope.selectedCollections?.length ? scope.selectedCollections : null);
 
@@ -125,17 +128,18 @@ async function extractContent({
 				}
 			}
 			else {
-				// No filtering - get all files
+				// No collection filtering - get all files
 				files = await fileService.readByQuery({
 					fields: directusFileFields,
 					filter: { _or: [{ folder: { _neq: folder } }, { folder: { _null: true } }] },
 					limit: -1,
 				});
 			}
+
+			res.write(' ...');
+			await saveToFile(files, 'files', fileService, folder, storage);
+			res.write('done\r\n\r\n');
 		}
-		res.write(' ...');
-		await saveToFile(files, 'files', fileService, folder, storage);
-		res.write('done\r\n\r\n');
 
 		return {
 			collections,

--- a/packages/migration-bundle/src/migration-endpoint/composables/extract-system.ts
+++ b/packages/migration-bundle/src/migration-endpoint/composables/extract-system.ts
@@ -252,8 +252,12 @@ async function extractSystemData({ res, services, accountability, schema, scope,
 		let flows: ModifiedFlowRaw[] = scope.flows ? await flowService.readByQuery({ fields: directusFlowFields, limit: -1 }) : [];
 
 		// Filter flows by selectedFlows if specified
+		// Accepts both flow ID and flow name for flexible filtering (similar to selectedExtensions)
 		if (scope.flows && scope.selectedFlows && scope.selectedFlows.length > 0) {
-			flows = flows.filter(f => scope.selectedFlows!.includes(f.id));
+			flows = flows.filter(f =>
+				scope.selectedFlows!.includes(f.id) ||
+				scope.selectedFlows!.includes(f.name),
+			);
 			res.write(`  (filtered to ${flows.length} selected flows)\r\n`);
 		}
 

--- a/packages/migration-bundle/src/migration-endpoint/composables/extract-system.ts
+++ b/packages/migration-bundle/src/migration-endpoint/composables/extract-system.ts
@@ -168,9 +168,37 @@ async function extractSystemData({ res, services, accountability, schema, scope,
 
 		// Folders: fetch only if explicitly enabled OR if files is enabled (folders needed for file organization)
 		// Removed scope.content check to prevent unwanted folder migration when only content is selected
-		const shouldFetchFolders = scope.folders === true || scope.files === true;
+		// Issue #009: Skip if selectedFolders is an empty array (explicit skip)
+		const hasEmptyFolderSelection = Array.isArray(scope.selectedFolders) && scope.selectedFolders.length === 0;
+		const shouldFetchFolders = !hasEmptyFolderSelection && (scope.folders === true || scope.files === true);
 		res.write(shouldFetchFolders ? '* Fetching folders' : '* Skipping folders\r\n\r\n');
-		const folders: Folder[] = shouldFetchFolders ? await folderService.readByQuery({ fields: directusFolderFields, filter: { id: { _neq: folder } }, limit: -1 }) : [];
+		let folders: Folder[] = shouldFetchFolders ? await folderService.readByQuery({ fields: directusFolderFields, filter: { id: { _neq: folder } }, limit: -1 }) : [];
+
+		// Issue #009: Filter folders by selectedFolders if specified
+		if (shouldFetchFolders && scope.selectedFolders && scope.selectedFolders.length > 0 && folders.length > 0) {
+			const beforeCount = folders.length;
+			// Include selected folders and their parent folders (to maintain structure)
+			const selectedIds = new Set(scope.selectedFolders);
+			const includedIds = new Set<string>();
+
+			// Helper to include folder and all its parents
+			const includeWithParents = (folderId: string) => {
+				includedIds.add(folderId);
+				const folder = folders.find(f => f.id === folderId);
+				if (folder?.parent) {
+					includeWithParents(folder.parent);
+				}
+			};
+
+			// Include all selected folders with their parents
+			scope.selectedFolders.forEach(id => {
+				const folder = folders.find(f => f.id === id);
+				if (folder) includeWithParents(id);
+			});
+
+			folders = folders.filter(f => includedIds.has(f.id));
+			res.write(` (filtered: ${folders.length}/${beforeCount})`);
+		}
 
 		if (shouldFetchFolders) {
 			res.write(' ...');
@@ -309,9 +337,13 @@ async function extractSystemData({ res, services, accountability, schema, scope,
 		res.write(scope.comments ? '* Fetching comments' : '* Skipping comments');
 		let comments: CommentRaw[] = scope.comments ? await commentService.readByQuery({ limit: -1 }) : [];
 
-		// Filter comments by collection if collection filtering is active
-		if (scope.comments && comments.length > 0) {
+		// Filter comments by collection if includeCommentsForContent is enabled (Issue #009)
+		// When true: only comments for selected collections are migrated
+		// When false or undefined: all comments are migrated (backward compatibility)
+		if (scope.comments && scope.includeCommentsForContent && comments.length > 0) {
+			const beforeCount = comments.length;
 			comments = comments.filter(comment => shouldIncludeCollection(comment.collection, scope));
+			res.write(` (filtered: ${comments.length}/${beforeCount})`);
 		}
 
 		if (scope.comments) {

--- a/packages/migration-bundle/src/migration-endpoint/composables/extract-system.ts
+++ b/packages/migration-bundle/src/migration-endpoint/composables/extract-system.ts
@@ -228,9 +228,17 @@ async function extractSystemData({ res, services, accountability, schema, scope,
 		// Filter panels by options.collection if collection filtering is active
 		if (scope.dashboards && panels.length > 0) {
 			panels = panels.filter(panel => {
-				// Panels without collection reference are always included
-				if (!panel.options?.collection) return true;
-				return shouldIncludeCollection(panel.options.collection, scope);
+				const panelCollection = panel.options?.collection;
+				// Null collection handling based on filter mode
+				if (!panelCollection) {
+					// Include mode: null does not match any selected collection
+					if (scope.selectedCollections && scope.selectedCollections.length > 0) {
+						return false;
+					}
+					// Exclude mode or no filter: null is not excluded
+					return true;
+				}
+				return shouldIncludeCollection(panelCollection, scope);
 			});
 		}
 
@@ -252,9 +260,17 @@ async function extractSystemData({ res, services, accountability, schema, scope,
 		// Also filter flows by options.collection if collection filtering is active
 		if (scope.flows && flows.length > 0) {
 			flows = flows.filter(flow => {
-				// Flows without collection reference are always included
-				if (!flow.options?.collection) return true;
-				return shouldIncludeCollection(flow.options.collection, scope);
+				const flowCollection = flow.options?.collection;
+				// Null collection handling based on filter mode
+				if (!flowCollection) {
+					// Include mode: null does not match any selected collection
+					if (scope.selectedCollections && scope.selectedCollections.length > 0) {
+						return false;
+					}
+					// Exclude mode or no filter: null is not excluded
+					return true;
+				}
+				return shouldIncludeCollection(flowCollection, scope);
 			});
 		}
 
@@ -311,8 +327,15 @@ async function extractSystemData({ res, services, accountability, schema, scope,
 		// Filter presets by collection if collection filtering is active
 		if (scope.presets && presets.length > 0) {
 			presets = presets.filter(preset => {
-				// Global presets (no collection) are always included
-				if (!preset.collection) return true;
+				// Null collection handling based on filter mode
+				if (!preset.collection) {
+					// Include mode: null does not match any selected collection
+					if (scope.selectedCollections && scope.selectedCollections.length > 0) {
+						return false;
+					}
+					// Exclude mode or no filter: null is not excluded
+					return true;
+				}
 				return shouldIncludeCollection(preset.collection, scope);
 			});
 		}

--- a/packages/migration-bundle/src/migration-endpoint/composables/extract-system.ts
+++ b/packages/migration-bundle/src/migration-endpoint/composables/extract-system.ts
@@ -73,57 +73,106 @@ async function extractSystemData({ res, services, accountability, schema, scope,
 	const shareService = new SharesService({ accountability, schema });
 
 	try {
-		res.write(scope.users ? '* Fetching roles' : '* Skipping roles\r\n\r\n');
-		const roles: RoleRaw[] = scope.users ? await roleService.readByQuery({ fields: directusRoleFields, limit: -1 }) : [];
+		// Get users granular options with defaults
+		const usersGranular = scope.usersGranular || {
+			roles: true,
+			policies: true,
+			permissions: true,
+			userAccounts: true,
+			access: true,
+		};
 
-		if (scope.users) {
+		const shouldFetchRoles = scope.users && usersGranular.roles;
+		const shouldFetchPolicies = scope.users && usersGranular.policies;
+		const shouldFetchPermissions = scope.users && usersGranular.permissions;
+		const shouldFetchUsers = scope.users && usersGranular.userAccounts;
+		const shouldFetchAccess = scope.users && usersGranular.access;
+
+		// Phase 6: Get users selection options
+		const usersSelection = scope.usersSelection || {};
+
+		res.write(shouldFetchRoles ? '* Fetching roles' : '* Skipping roles\r\n\r\n');
+		let roles: RoleRaw[] = shouldFetchRoles ? await roleService.readByQuery({ fields: directusRoleFields, limit: -1 }) : [];
+
+		// Phase 6: Filter roles by selection
+		if (shouldFetchRoles && usersSelection.selectedRoles && usersSelection.selectedRoles.length > 0) {
+			roles = roles.filter(r => usersSelection.selectedRoles!.includes(r.id));
+			res.write(`  (filtered to ${roles.length} selected roles)\r\n`);
+		}
+
+		if (shouldFetchRoles) {
 			res.write(' ...');
 			await saveToFile(roles, 'roles', fileService, folder, storage);
 			res.write('done\r\n\r\n');
 		}
 
-		res.write(scope.users ? '* Fetching policies' : '* Skipping policies\r\n\r\n');
-		const policies: PolicyRaw[] = scope.users ? await policyService.readByQuery({ fields: directusPolicyFields, limit: -1 }) : [];
+		res.write(shouldFetchPolicies ? '* Fetching policies' : '* Skipping policies\r\n\r\n');
+		let policies: PolicyRaw[] = shouldFetchPolicies ? await policyService.readByQuery({ fields: directusPolicyFields, limit: -1 }) : [];
 
-		if (scope.users) {
+		// Phase 6: Filter policies by selection
+		if (shouldFetchPolicies && usersSelection.selectedPolicies && usersSelection.selectedPolicies.length > 0) {
+			policies = policies.filter(p => usersSelection.selectedPolicies!.includes(p.id));
+			res.write(`  (filtered to ${policies.length} selected policies)\r\n`);
+		}
+
+		if (shouldFetchPolicies) {
 			res.write(' ...');
 			await saveToFile(policies, 'policies', fileService, folder, storage);
 			res.write('done\r\n\r\n');
 		}
 
-		res.write(scope.users ? '* Fetching permissions' : '* Skipping permissions\r\n\r\n');
-		const permissions: Permission[] = scope.users ? await permissionService.readByQuery({ limit: -1 }) : [];
+		res.write(shouldFetchPermissions ? '* Fetching permissions' : '* Skipping permissions\r\n\r\n');
+		let permissions: Permission[] = shouldFetchPermissions ? await permissionService.readByQuery({ limit: -1 }) : [];
 
-		if (scope.users) {
+		// Phase 6: Filter permissions by selection
+		if (shouldFetchPermissions && usersSelection.selectedPermissions && usersSelection.selectedPermissions.length > 0) {
+			permissions = permissions.filter(p => usersSelection.selectedPermissions!.includes(p.id));
+			res.write(`  (filtered to ${permissions.length} selected permissions)\r\n`);
+		}
+
+		if (shouldFetchPermissions) {
 			res.write(' ...');
 			await saveToFile(permissions, 'permissions', fileService, folder, storage);
 			res.write('done\r\n\r\n');
 		}
 
-		res.write(scope.users ? '* Fetching users' : '* Skipping users\r\n\r\n');
-		const users: UserRaw[] = scope.users ? await userService.readByQuery({ fields: directusUserFields, limit: -1 }) : [];
+		res.write(shouldFetchUsers ? '* Fetching users' : '* Skipping users\r\n\r\n');
+		let users: UserRaw[] = shouldFetchUsers ? await userService.readByQuery({ fields: directusUserFields, limit: -1 }) : [];
 
-		if (scope.users) {
+		// Phase 6: Filter users by selection
+		if (shouldFetchUsers && usersSelection.selectedUsers && usersSelection.selectedUsers.length > 0) {
+			users = users.filter(u => usersSelection.selectedUsers!.includes(u.id));
+			res.write(`  (filtered to ${users.length} selected users)\r\n`);
+		}
+
+		if (shouldFetchUsers) {
 			res.write(' ...');
 			await saveToFile(users, 'users', fileService, folder, storage);
 			res.write('done\r\n\r\n');
 		}
 
-		res.write(scope.users ? '* Fetching access' : '* Skipping access\r\n\r\n');
-		const access: Access[] = scope.users ? await accessService.readByQuery({ limit: -1 }) : [];
+		res.write(shouldFetchAccess ? '* Fetching access' : '* Skipping access\r\n\r\n');
+		let access: Access[] = shouldFetchAccess ? await accessService.readByQuery({ limit: -1 }) : [];
 
-		if (scope.users) {
+		// Phase 6: Filter access by selection
+		if (shouldFetchAccess && usersSelection.selectedAccess && usersSelection.selectedAccess.length > 0) {
+			access = access.filter(a => usersSelection.selectedAccess!.includes(Number(a.id)));
+			res.write(`  (filtered to ${access.length} selected access rules)\r\n`);
+		}
+
+		if (shouldFetchAccess) {
 			res.write(' ...');
 			await saveToFile(access, 'access', fileService, folder, storage);
 			res.write('done\r\n\r\n');
 		}
 
-		res.write(scope.content ? '* Fetching folders' : '* Skipping folders\r\n\r\n');
-		// TODO Fix 6.4: Filter folders based on which files are being migrated
-		// Currently loads all folders - duplicates are prevented in migrate-folders.ts
-		const folders: Folder[] = scope.content ? await folderService.readByQuery({ fields: directusFolderFields, filter: { id: { _neq: folder } }, limit: -1 }) : [];
+		// Folders: fetch only if explicitly enabled OR if files is enabled (folders needed for file organization)
+		// Removed scope.content check to prevent unwanted folder migration when only content is selected
+		const shouldFetchFolders = scope.folders === true || scope.files === true;
+		res.write(shouldFetchFolders ? '* Fetching folders' : '* Skipping folders\r\n\r\n');
+		const folders: Folder[] = shouldFetchFolders ? await folderService.readByQuery({ fields: directusFolderFields, filter: { id: { _neq: folder } }, limit: -1 }) : [];
 
-		if (scope.content) {
+		if (shouldFetchFolders) {
 			res.write(' ...');
 			await saveToFile(folders, 'folders', fileService, folder, storage);
 			res.write('done\r\n\r\n');
@@ -159,7 +208,13 @@ async function extractSystemData({ res, services, accountability, schema, scope,
 		res.write(scope.flows ? '* Fetching flows' : '* Skipping flows\r\n\r\n');
 		let flows: ModifiedFlowRaw[] = scope.flows ? await flowService.readByQuery({ fields: directusFlowFields, limit: -1 }) : [];
 
-		// Filter flows by options.collection if collection filtering is active
+		// Filter flows by selectedFlows if specified
+		if (scope.flows && scope.selectedFlows && scope.selectedFlows.length > 0) {
+			flows = flows.filter(f => scope.selectedFlows!.includes(f.id));
+			res.write(`  (filtered to ${flows.length} selected flows)\r\n`);
+		}
+
+		// Also filter flows by options.collection if collection filtering is active
 		if (scope.flows && flows.length > 0) {
 			flows = flows.filter(flow => {
 				// Flows without collection reference are always included
@@ -178,7 +233,7 @@ async function extractSystemData({ res, services, accountability, schema, scope,
 		let operations: OperationRaw[] = scope.flows ? await operationService.readByQuery({ fields: directusOperationFields, limit: -1 }) : [];
 
 		// Filter operations: only include operations belonging to included flows
-		if (scope.flows && operations.length > 0) {
+		if (scope.flows && flows.length > 0) {
 			const includedFlowIds = new Set(flows.map(f => f.id));
 			operations = operations.filter(op => includedFlowIds.has(op.flow));
 		}
@@ -189,17 +244,31 @@ async function extractSystemData({ res, services, accountability, schema, scope,
 			res.write('done\r\n\r\n');
 		}
 
-		res.write('* Fetching settings');
-		const settings: Settings = await settingsService.readSingleton({ fields: directusSettingsFields });
-		res.write(' ...');
-		await saveToFile(settings, 'settings', fileService, folder, storage);
-		res.write('done\r\n\r\n');
+		// Settings: fetch only if scope.settings is not explicitly false (default true for backward compatibility)
+		const shouldFetchSettings = scope.settings !== false;
+		res.write(shouldFetchSettings ? '* Fetching settings' : '* Skipping settings\r\n\r\n');
+		const settings: Settings | null = shouldFetchSettings
+			? await settingsService.readSingleton({ fields: directusSettingsFields })
+			: null;
 
-		res.write('* Fetching translations');
-		const translations: Translation[] = await translationService.readByQuery({ limit: -1 });
-		res.write(' ...');
-		await saveToFile(translations, 'translations', fileService, folder, storage);
-		res.write('done\r\n\r\n');
+		if (shouldFetchSettings && settings) {
+			res.write(' ...');
+			await saveToFile(settings, 'settings', fileService, folder, storage);
+			res.write('done\r\n\r\n');
+		}
+
+		// Translations: fetch only if scope.translations is not explicitly false (default true for backward compatibility)
+		const shouldFetchTranslations = scope.translations !== false;
+		res.write(shouldFetchTranslations ? '* Fetching translations' : '* Skipping translations\r\n\r\n');
+		const translations: Translation[] = shouldFetchTranslations
+			? await translationService.readByQuery({ limit: -1 })
+			: [];
+
+		if (shouldFetchTranslations) {
+			res.write(' ...');
+			await saveToFile(translations, 'translations', fileService, folder, storage);
+			res.write('done\r\n\r\n');
+		}
 
 		res.write(scope.presets ? '* Fetching presets' : '* Skipping presets');
 		let presets: Preset[] = scope.presets ? await presetService.readByQuery({ fields: directusPresetFields, limit: -1 }) : [];
@@ -220,7 +289,16 @@ async function extractSystemData({ res, services, accountability, schema, scope,
 		}
 
 		res.write(scope.extensions ? '* Fetching extensions' : '* Skipping extensions\r\n\r\n');
-		const extensions: Extension[] = scope.extensions ? await extensionService.readAll() : [];
+		let extensions: Extension[] = scope.extensions ? await extensionService.readAll() : [];
+
+		// Filter extensions by selectedExtensions if specified
+		if (scope.extensions && scope.selectedExtensions && scope.selectedExtensions.length > 0) {
+			extensions = extensions.filter(e =>
+				scope.selectedExtensions!.includes(e.schema?.name || e.id) ||
+				(e.bundle && scope.selectedExtensions!.includes(e.bundle)),
+			);
+			res.write(`  (filtered to ${extensions.length} selected extensions)\r\n`);
+		}
 
 		if (scope.extensions) {
 			res.write(' ...');

--- a/packages/migration-bundle/src/migration-endpoint/composables/extract-system.ts
+++ b/packages/migration-bundle/src/migration-endpoint/composables/extract-system.ts
@@ -82,14 +82,21 @@ async function extractSystemData({ res, services, accountability, schema, scope,
 			access: true,
 		};
 
-		const shouldFetchRoles = scope.users && usersGranular.roles;
-		const shouldFetchPolicies = scope.users && usersGranular.policies;
-		const shouldFetchPermissions = scope.users && usersGranular.permissions;
-		const shouldFetchUsers = scope.users && usersGranular.userAccounts;
-		const shouldFetchAccess = scope.users && usersGranular.access;
-
 		// Phase 6: Get users selection options
 		const usersSelection = scope.usersSelection || {};
+
+		// Empty selection = skip (same pattern as selectedFolders, selectedPresets, etc.)
+		const hasEmptyRolesSelection = Array.isArray(usersSelection.selectedRoles) && usersSelection.selectedRoles.length === 0;
+		const hasEmptyPoliciesSelection = Array.isArray(usersSelection.selectedPolicies) && usersSelection.selectedPolicies.length === 0;
+		const hasEmptyPermissionsSelection = Array.isArray(usersSelection.selectedPermissions) && usersSelection.selectedPermissions.length === 0;
+		const hasEmptyUsersSelection = Array.isArray(usersSelection.selectedUsers) && usersSelection.selectedUsers.length === 0;
+		const hasEmptyAccessSelection = Array.isArray(usersSelection.selectedAccess) && usersSelection.selectedAccess.length === 0;
+
+		const shouldFetchRoles = scope.users && usersGranular.roles && !hasEmptyRolesSelection;
+		const shouldFetchPolicies = scope.users && usersGranular.policies && !hasEmptyPoliciesSelection;
+		const shouldFetchPermissions = scope.users && usersGranular.permissions && !hasEmptyPermissionsSelection;
+		const shouldFetchUsers = scope.users && usersGranular.userAccounts && !hasEmptyUsersSelection;
+		const shouldFetchAccess = scope.users && usersGranular.access && !hasEmptyAccessSelection;
 
 		res.write(shouldFetchRoles ? '* Fetching roles' : '* Skipping roles\r\n\r\n');
 		let roles: RoleRaw[] = shouldFetchRoles ? await roleService.readByQuery({ fields: directusRoleFields, limit: -1 }) : [];

--- a/packages/migration-bundle/src/migration-endpoint/composables/extract-system.ts
+++ b/packages/migration-bundle/src/migration-endpoint/composables/extract-system.ts
@@ -1,6 +1,25 @@
 import type { Accountability, Permission, Preset, SchemaOverview, Settings, Share } from '@directus/types';
 import type { Access, CommentRaw, DashboardRaw, DirectusError, Extension, Folder, ModifiedFlowRaw, OperationRaw, PanelRaw, PolicyRaw, RoleRaw, Scope, SystemExtract, Translation, UserRaw } from '../../types/extension';
 import saveToFile from '../../utils/save-file';
+
+function shouldIncludeCollection(collectionName: string, scope: Scope): boolean {
+	const { selectedCollections, excludedCollections } = scope;
+
+	// If no filtering specified, include all
+	if ((!selectedCollections || selectedCollections.length === 0) &&
+		(!excludedCollections || excludedCollections.length === 0)) {
+		return true;
+	}
+
+	if (selectedCollections && selectedCollections.length > 0) {
+		return selectedCollections.includes(collectionName);
+	}
+	if (excludedCollections && excludedCollections.length > 0) {
+		return !excludedCollections.includes(collectionName);
+	}
+	return true;
+}
+
 import {
 	directusDashboardFields,
 	directusFlowFields,
@@ -100,6 +119,8 @@ async function extractSystemData({ res, services, accountability, schema, scope,
 		}
 
 		res.write(scope.content ? '* Fetching folders' : '* Skipping folders\r\n\r\n');
+		// TODO Fix 6.4: Filter folders based on which files are being migrated
+		// Currently loads all folders - duplicates are prevented in migrate-folders.ts
 		const folders: Folder[] = scope.content ? await folderService.readByQuery({ fields: directusFolderFields, filter: { id: { _neq: folder } }, limit: -1 }) : [];
 
 		if (scope.content) {
@@ -118,7 +139,16 @@ async function extractSystemData({ res, services, accountability, schema, scope,
 		}
 
 		res.write(scope.dashboards ? '* Fetching panels' : '* Skipping panels\r\n\r\n');
-		const panels: PanelRaw[] = scope.dashboards ? await panelService.readByQuery({ fields: directusPanelFields, limit: -1 }) : [];
+		let panels: PanelRaw[] = scope.dashboards ? await panelService.readByQuery({ fields: directusPanelFields, limit: -1 }) : [];
+
+		// Filter panels by options.collection if collection filtering is active
+		if (scope.dashboards && panels.length > 0) {
+			panels = panels.filter(panel => {
+				// Panels without collection reference are always included
+				if (!panel.options?.collection) return true;
+				return shouldIncludeCollection(panel.options.collection, scope);
+			});
+		}
 
 		if (scope.dashboards) {
 			res.write(' ...');
@@ -127,7 +157,16 @@ async function extractSystemData({ res, services, accountability, schema, scope,
 		}
 
 		res.write(scope.flows ? '* Fetching flows' : '* Skipping flows\r\n\r\n');
-		const flows: ModifiedFlowRaw[] = scope.flows ? await flowService.readByQuery({ fields: directusFlowFields, limit: -1 }) : [];
+		let flows: ModifiedFlowRaw[] = scope.flows ? await flowService.readByQuery({ fields: directusFlowFields, limit: -1 }) : [];
+
+		// Filter flows by options.collection if collection filtering is active
+		if (scope.flows && flows.length > 0) {
+			flows = flows.filter(flow => {
+				// Flows without collection reference are always included
+				if (!flow.options?.collection) return true;
+				return shouldIncludeCollection(flow.options.collection, scope);
+			});
+		}
 
 		if (scope.flows) {
 			res.write(' ...');
@@ -136,7 +175,13 @@ async function extractSystemData({ res, services, accountability, schema, scope,
 		}
 
 		res.write(scope.flows ? '* Fetching operations' : '* Skipping operations\r\n\r\n');
-		const operations: OperationRaw[] = scope.flows ? await operationService.readByQuery({ fields: directusOperationFields, limit: -1 }) : [];
+		let operations: OperationRaw[] = scope.flows ? await operationService.readByQuery({ fields: directusOperationFields, limit: -1 }) : [];
+
+		// Filter operations: only include operations belonging to included flows
+		if (scope.flows && operations.length > 0) {
+			const includedFlowIds = new Set(flows.map(f => f.id));
+			operations = operations.filter(op => includedFlowIds.has(op.flow));
+		}
 
 		if (scope.flows) {
 			res.write(' ...');
@@ -157,7 +202,16 @@ async function extractSystemData({ res, services, accountability, schema, scope,
 		res.write('done\r\n\r\n');
 
 		res.write(scope.presets ? '* Fetching presets' : '* Skipping presets');
-		const presets: Preset[] = scope.presets ? await presetService.readByQuery({ fields: directusPresetFields, limit: -1 }) : [];
+		let presets: Preset[] = scope.presets ? await presetService.readByQuery({ fields: directusPresetFields, limit: -1 }) : [];
+
+		// Filter presets by collection if collection filtering is active
+		if (scope.presets && presets.length > 0) {
+			presets = presets.filter(preset => {
+				// Global presets (no collection) are always included
+				if (!preset.collection) return true;
+				return shouldIncludeCollection(preset.collection, scope);
+			});
+		}
 
 		if (scope.presets) {
 			res.write(' ...');
@@ -175,7 +229,12 @@ async function extractSystemData({ res, services, accountability, schema, scope,
 		}
 
 		res.write(scope.comments ? '* Fetching comments' : '* Skipping comments');
-		const comments: CommentRaw[] = scope.comments ? await commentService.readByQuery({ limit: -1 }) : [];
+		let comments: CommentRaw[] = scope.comments ? await commentService.readByQuery({ limit: -1 }) : [];
+
+		// Filter comments by collection if collection filtering is active
+		if (scope.comments && comments.length > 0) {
+			comments = comments.filter(comment => shouldIncludeCollection(comment.collection, scope));
+		}
 
 		if (scope.comments) {
 			res.write(' ...');

--- a/packages/migration-bundle/src/migration-endpoint/composables/extract-system.ts
+++ b/packages/migration-bundle/src/migration-endpoint/composables/extract-system.ts
@@ -327,9 +327,11 @@ async function extractSystemData({ res, services, accountability, schema, scope,
 		let extensions: Extension[] = scope.extensions ? await extensionService.readAll() : [];
 
 		// Filter extensions by selectedExtensions if specified
+		// Accepts extension ID, schema.name, or bundle name for flexible filtering
 		if (scope.extensions && scope.selectedExtensions && scope.selectedExtensions.length > 0) {
 			extensions = extensions.filter(e =>
-				scope.selectedExtensions!.includes(e.schema?.name || e.id) ||
+				scope.selectedExtensions!.includes(e.id) ||
+				(e.schema?.name && scope.selectedExtensions!.includes(e.schema.name)) ||
 				(e.bundle && scope.selectedExtensions!.includes(e.bundle)),
 			);
 			res.write(`  (filtered to ${extensions.length} selected extensions)\r\n`);

--- a/packages/migration-bundle/src/migration-endpoint/composables/migrate-dashboards.ts
+++ b/packages/migration-bundle/src/migration-endpoint/composables/migrate-dashboards.ts
@@ -3,17 +3,44 @@ import type { DashboardRaw, DirectusError } from '../../types/extension';
 import type { Schema } from '../api';
 import { createDashboard, readDashboards } from '@directus/sdk';
 
-async function migrateDashboards({ res, client, dashboards, dry_run = false }: { res: any; client: RestClient<Schema>; dashboards: DashboardRaw[] | null; dry_run: boolean }): Promise<{ response: string; name: string } | DirectusError> {
+async function migrateDashboards({
+	res,
+	client,
+	dashboards,
+	selectedDashboards,
+	dry_run = false,
+}: {
+	res: any;
+	client: RestClient<Schema>;
+	dashboards: DashboardRaw[] | null;
+	selectedDashboards?: string[];
+	dry_run: boolean;
+}): Promise<{ response: string; name: string } | DirectusError> {
 	if (!dashboards) {
 		res.write('* Couldn\'t read data from extract\r\n\r\n');
 		return { name: 'Directus Error', status: 404, errors: [{ message: 'No dashboards found' }] };
 	}
-	else if (dashboards.length === 0) {
+
+	// Issue #014: Handle empty selection = skip
+	if (selectedDashboards && selectedDashboards.length === 0) {
+		res.write('* Dashboards skipped (empty selection)\r\n\r\n');
+		return { response: 'Skipped', name: 'Insights' };
+	}
+
+	// Issue #014: Filter by selected dashboard IDs
+	let filteredBySelection = dashboards;
+	if (selectedDashboards && selectedDashboards.length > 0) {
+		const selectedIds = new Set(selectedDashboards);
+		filteredBySelection = dashboards.filter((dashboard) => selectedIds.has(dashboard.id));
+		res.write(`* Filtering to ${filteredBySelection.length} selected dashboards (from ${dashboards.length})\r\n\r\n`);
+	}
+
+	if (filteredBySelection.length === 0) {
 		res.write('* No dashboards to migrate\r\n\r\n');
 		return { response: 'Empty', name: 'Insights' };
 	}
 
-	res.write(`* [Local] Found ${dashboards.length} dashboards\r\n\r\n`);
+	res.write(`* [Local] Found ${filteredBySelection.length} dashboards\r\n\r\n`);
 
 	try {
 		// Fetch existing dashboards
@@ -29,7 +56,7 @@ async function migrateDashboards({ res, client, dashboards, dry_run = false }: {
 
 		const existingDashboardIds = new Set(existingDashboards.map((dashboard) => dashboard.id));
 
-		const filteredDashboards = dashboards.filter((dashboard) => {
+		const dashboardsToCreate = filteredBySelection.filter((dashboard) => {
 			if (existingDashboardIds.has(dashboard.id)) {
 				return false;
 			}
@@ -41,13 +68,15 @@ async function migrateDashboards({ res, client, dashboards, dry_run = false }: {
 			return newDash;
 		});
 
-		res.write(filteredDashboards.length > 0 ? `* [Remote] Uploading ${filteredDashboards.length} ${filteredDashboards.length > 1 ? 'Dashboards' : 'Dashboard'} ` : '* No Dashboards to migrate\r\n\r\n');
+		res.write(dashboardsToCreate.length > 0 ? `* [Remote] Uploading ${dashboardsToCreate.length} ${dashboardsToCreate.length > 1 ? 'Dashboards' : 'Dashboard'} ` : '* No Dashboards to migrate\r\n\r\n');
 
-		if (filteredDashboards.length > 0) {
-			await Promise.all(filteredDashboards.map(async (dashboard) => {
+		if (dashboardsToCreate.length > 0) {
+			for (const dashboard of dashboardsToCreate) {
 				res.write('.');
-				await client.request(createDashboard(dashboard));
-			}));
+				if (!dry_run) {
+					await client.request(createDashboard(dashboard));
+				}
+			}
 
 			res.write(dry_run ? 'skipped\r\n\r\n' : 'done\r\n\r\n');
 			res.write('* Dashboard Migration Complete\r\n\r\n');

--- a/packages/migration-bundle/src/migration-endpoint/composables/migrate-folders.ts
+++ b/packages/migration-bundle/src/migration-endpoint/composables/migrate-folders.ts
@@ -29,13 +29,23 @@ async function migrateFolders({ res, client, folders, dry_run = false }: { res: 
 
 		const existingFolderIds = new Set(existingFolders.map((folder) => folder.id));
 
-		const foldersToAdd = folders.filter((folder) => {
-			if (existingFolderIds.has(folder.id)) {
-				return false;
-			}
+		// Fix 6.5: Track skipped folders for better logging
+		const foldersToAdd: Folder[] = [];
+		const skippedFolders: Folder[] = [];
 
-			return true;
-		});
+		for (const folder of folders) {
+			if (existingFolderIds.has(folder.id)) {
+				skippedFolders.push(folder);
+			}
+			else {
+				foldersToAdd.push(folder);
+			}
+		}
+
+		// Log skipped folders
+		if (skippedFolders.length > 0) {
+			res.write(`* [Remote] Skipping ${skippedFolders.length} existing folder(s): ${skippedFolders.map(f => f.name).join(', ')}\r\n\r\n`);
+		}
 
 		res.write(foldersToAdd.length > 0 ? `* [Remote] Uploading ${foldersToAdd.length} ${foldersToAdd.length > 1 ? 'Folders' : 'Folder'} ` : '* No Folders to migrate\r\n\r\n');
 

--- a/packages/migration-bundle/src/migration-endpoint/composables/migrate-panels.ts
+++ b/packages/migration-bundle/src/migration-endpoint/composables/migrate-panels.ts
@@ -3,17 +3,44 @@ import type { DirectusError, PanelRaw } from '../../types/extension';
 import type { Schema } from '../api';
 import { createPanel, readPanels } from '@directus/sdk';
 
-async function migratePanels({ res, client, panels, dry_run = false }: { res: any; client: RestClient<Schema>; panels: PanelRaw[] | null; dry_run: boolean }): Promise<{ response: string; name: string } | DirectusError> {
+async function migratePanels({
+	res,
+	client,
+	panels,
+	selectedDashboards,
+	dry_run = false,
+}: {
+	res: any;
+	client: RestClient<Schema>;
+	panels: PanelRaw[] | null;
+	selectedDashboards?: string[];
+	dry_run: boolean;
+}): Promise<{ response: string; name: string } | DirectusError> {
 	if (!panels) {
 		res.write('* Couldn\'t read data from extract\r\n\r\n');
 		return { name: 'Directus Error', status: 404, errors: [{ message: 'No panels found' }] };
 	}
-	else if (panels.length === 0) {
+
+	// Issue #014: Skip panels if dashboards were skipped (empty selection)
+	if (selectedDashboards && selectedDashboards.length === 0) {
+		res.write('* Panels skipped (dashboards empty selection)\r\n\r\n');
+		return { response: 'Skipped', name: 'Panels' };
+	}
+
+	// Issue #014: Filter panels by selected dashboards
+	let filteredByDashboard = panels;
+	if (selectedDashboards && selectedDashboards.length > 0) {
+		const selectedDashboardIds = new Set(selectedDashboards);
+		filteredByDashboard = panels.filter((panel) => selectedDashboardIds.has(panel.dashboard));
+		res.write(`* Filtering to ${filteredByDashboard.length} panels for selected dashboards (from ${panels.length})\r\n\r\n`);
+	}
+
+	if (filteredByDashboard.length === 0) {
 		res.write('* No panels to migrate\r\n\r\n');
 		return { response: 'Empty', name: 'Panels' };
 	}
 
-	res.write(`* [Local] Found ${panels.length} panels\r\n\r\n`);
+	res.write(`* [Local] Found ${filteredByDashboard.length} panels\r\n\r\n`);
 
 	try {
 		// Fetch existing panels
@@ -29,7 +56,7 @@ async function migratePanels({ res, client, panels, dry_run = false }: { res: an
 
 		const existingPanelIds = new Set(existingPanels.map((panel) => panel.id));
 
-		const filteredPanels = panels.filter((panel) => {
+		const panelsToCreate = filteredByDashboard.filter((panel) => {
 			if (existingPanelIds.has(panel.id)) {
 				return false;
 			}
@@ -37,13 +64,15 @@ async function migratePanels({ res, client, panels, dry_run = false }: { res: an
 			return true;
 		});
 
-		res.write(filteredPanels.length > 0 ? `* [Remote] Uploading ${filteredPanels.length} ${filteredPanels.length > 1 ? 'Panels' : 'Panel'} ` : '* No Panels to migrate\r\n\r\n');
+		res.write(panelsToCreate.length > 0 ? `* [Remote] Uploading ${panelsToCreate.length} ${panelsToCreate.length > 1 ? 'Panels' : 'Panel'} ` : '* No Panels to migrate\r\n\r\n');
 
-		if (filteredPanels.length > 0) {
-			await Promise.all(filteredPanels.map(async (panel) => {
+		if (panelsToCreate.length > 0) {
+			for (const panel of panelsToCreate) {
 				res.write('.');
-				await client.request(createPanel(panel));
-			}));
+				if (!dry_run) {
+					await client.request(createPanel(panel));
+				}
+			}
 
 			res.write(dry_run ? 'skipped\r\n\r\n' : 'done\r\n\r\n');
 			res.write('* Panel Migration Complete\r\n\r\n');

--- a/packages/migration-bundle/src/migration-endpoint/composables/migrate-presets.ts
+++ b/packages/migration-bundle/src/migration-endpoint/composables/migrate-presets.ts
@@ -24,6 +24,7 @@ async function migratePresets({ res, client, presets, dry_run = false }: { res: 
 			delete preset.id;
 			const cleanPreset = { ...preset };
 			cleanPreset.user = null;
+			cleanPreset.role = null; // Null out role to prevent FK error when migrating without users
 			return cleanPreset;
 		});
 

--- a/packages/migration-bundle/src/migration-endpoint/composables/migrate-presets.ts
+++ b/packages/migration-bundle/src/migration-endpoint/composables/migrate-presets.ts
@@ -4,22 +4,50 @@ import type { DirectusError } from '../../types/extension';
 import type { Schema } from '../api';
 import { createPresets } from '@directus/sdk';
 
-async function migratePresets({ res, client, presets, dry_run = false }: { res: any; client: RestClient<Schema>; presets: Preset[] | null; dry_run: boolean }): Promise<{ response: string; name: string } | DirectusError> {
+async function migratePresets({
+	res,
+	client,
+	presets,
+	selectedPresets,
+	dry_run = false,
+}: {
+	res: any;
+	client: RestClient<Schema>;
+	presets: Preset[] | null;
+	selectedPresets?: string[];
+	dry_run: boolean;
+}): Promise<{ response: string; name: string } | DirectusError> {
 	if (!presets) {
 		res.write('* Couldn\'t read data from extract\r\n\r\n');
 		return { name: 'Directus Error', status: 404, errors: [{ message: 'No presets found' }] };
 	}
-	else if (presets.length === 0) {
+
+	// Issue #014: Handle empty selection = skip
+	if (selectedPresets && selectedPresets.length === 0) {
+		res.write('* Presets skipped (empty selection)\r\n\r\n');
+		return { response: 'Skipped', name: 'Presets' };
+	}
+
+	// Issue #014: Filter by selected preset IDs
+	let filteredPresets = presets;
+	if (selectedPresets && selectedPresets.length > 0) {
+		// Convert IDs to strings for comparison (presets use numeric IDs)
+		const selectedIds = new Set(selectedPresets.map((id) => String(id)));
+		filteredPresets = presets.filter((preset) => selectedIds.has(String(preset.id)));
+		res.write(`* Filtering to ${filteredPresets.length} selected presets (from ${presets.length})\r\n\r\n`);
+	}
+
+	if (filteredPresets.length === 0) {
 		res.write('* No presets to migrate\r\n\r\n');
 		return { response: 'Empty', name: 'Presets' };
 	}
 
-	res.write(`* [Local] Found ${presets.length} presets\r\n\r\n`);
+	res.write(`* [Local] Found ${filteredPresets.length} presets\r\n\r\n`);
 
 	try {
-		res.write(presets.length > 0 ? `* [Remote] Uploading ${presets.length} ${presets.length > 1 ? 'Presets' : 'Preset'} ` : '* No Presets to migrate\r\n\r\n');
+		res.write(filteredPresets.length > 0 ? `* [Remote] Uploading ${filteredPresets.length} ${filteredPresets.length > 1 ? 'Presets' : 'Preset'} ` : '* No Presets to migrate\r\n\r\n');
 
-		const presetsToAdd = presets.map((preset) => {
+		const presetsToAdd = filteredPresets.map((preset) => {
 			// Remove the id field from the presets so we don't have to reset the autoincrement on the db
 			delete preset.id;
 			const cleanPreset = { ...preset };

--- a/packages/migration-bundle/src/migration-endpoint/composables/migrate-schema.ts
+++ b/packages/migration-bundle/src/migration-endpoint/composables/migrate-schema.ts
@@ -2,12 +2,21 @@ import type { RestClient, SchemaDiffOutput, SchemaSnapshotOutput } from '@direct
 import type { DirectusError } from '../../types/extension';
 import type { Schema } from '../api';
 import { schemaApply, schemaDiff } from '@directus/sdk';
+import { filterSchemaDiff, getCollectionsFromSchema } from '../../utils/filter-schema-diff';
 
 export async function migrateSchema({ res, client, schema, dry_run = false, force = false }: { res: any; client: RestClient<Schema>; schema: SchemaSnapshotOutput; dry_run: boolean; force: boolean }): Promise<SchemaDiffOutput | DirectusError> {
 	try {
+		// Get collections from the filtered schema for diff filtering
+		const schemaCollections = getCollectionsFromSchema(schema);
+
+		// Debug: Log schema being sent (using res.write so it appears in output)
+		res.write(`[DEBUG] Sending schema with ${schemaCollections.size} collections: ${Array.from(schemaCollections).join(', ')}\r\n`);
+		res.write(`[DEBUG] Schema fields count: ${(schema as any).fields?.length || 0}\r\n`);
+		res.write(`[DEBUG] Schema relations count: ${(schema as any).relations?.length || 0}\r\n\r\n`);
+
 		res.write('1. Comparing Schemas ...');
 
-		const diff: SchemaDiffOutput = force
+		const rawDiff: SchemaDiffOutput = force
 			? await client.request(() => ({
 				body: JSON.stringify(schema),
 				method: 'POST',
@@ -15,27 +24,55 @@ export async function migrateSchema({ res, client, schema, dry_run = false, forc
 			}))
 			: await client.request(schemaDiff(schema));
 
+		// Filter the diff to exclude directus_* collections
+		const diff = filterSchemaDiff(rawDiff, schemaCollections);
+
+		// Debug: Log diff info BEFORE filtering
+		if ('diff' in rawDiff && rawDiff.diff) {
+			const rawCollections = rawDiff.diff.collections?.map((c: any) => c.collection) || [];
+			res.write(`[DEBUG] RAW diff collections (${rawCollections.length}): ${rawCollections.join(', ')}\r\n`);
+		}
+
+		// Debug: Log diff info AFTER filtering
+		if ('diff' in diff && diff.diff) {
+			const filteredCollections = diff.diff.collections?.map((c: any) => c.collection) || [];
+			const diffFields = diff.diff.fields?.length || 0;
+			const diffRelations = diff.diff.relations?.length || 0;
+			res.write(`[DEBUG] FILTERED diff collections (${filteredCollections.length}): ${filteredCollections.join(', ')}\r\n`);
+			res.write(`[DEBUG] FILTERED diff: ${filteredCollections.length} collections, ${diffFields} fields, ${diffRelations} relations\r\n`);
+		}
+
 		if (!('hash' in diff)) {
 			res.write('match\r\n\r\n');
 		}
 		else {
-			res.write('done\r\n\r\n');
+			// Check if filtered diff has any changes
+			const hasChanges = (diff.diff?.collections?.length || 0) > 0 ||
+				(diff.diff?.fields?.length || 0) > 0 ||
+				(diff.diff?.relations?.length || 0) > 0;
 
-			res.write('2. Applying Schemas ...');
-
-			if (!dry_run) {
-				await (!force
-					? client.request(schemaApply(diff))
-					: client.request(() => ({
-							body: JSON.stringify(diff),
-							method: 'POST',
-							path: '/schema/apply?force=true',
-						})));
-
-				res.write('done\r\n\r\n');
+			if (!hasChanges) {
+				res.write('match (after filtering)\r\n\r\n');
 			}
 			else {
-				res.write('skipped\r\n\r\n');
+				res.write('done\r\n\r\n');
+
+				res.write('2. Applying Schemas ...');
+
+				if (!dry_run) {
+					await (!force
+						? client.request(schemaApply(diff))
+						: client.request(() => ({
+								body: JSON.stringify(diff),
+								method: 'POST',
+								path: '/schema/apply?force=true',
+							})));
+
+					res.write('done\r\n\r\n');
+				}
+				else {
+					res.write('skipped\r\n\r\n');
+				}
 			}
 		}
 

--- a/packages/migration-bundle/src/migration-endpoint/composables/migrate-settings.ts
+++ b/packages/migration-bundle/src/migration-endpoint/composables/migrate-settings.ts
@@ -49,12 +49,44 @@ function mergeJsonStrings(current: string, incoming: string): string {
 	}
 }
 
-async function migrateSettings({ res, client, settings, dry_run = false }: { res: any; client: RestClient<Schema>; settings: Settings | null; dry_run: boolean }): Promise<{ response: string; name: string } | DirectusError> {
+async function migrateSettings({
+	res,
+	client,
+	settings,
+	selectedSettings,
+	dry_run = false,
+}: {
+	res: any;
+	client: RestClient<Schema>;
+	settings: Settings | null;
+	selectedSettings?: string[];
+	dry_run: boolean;
+}): Promise<{ response: string; name: string } | DirectusError> {
 	res.write('* [Local] Loading Settings\r\n\r\n');
+
+	// Issue #013: Handle empty selection = skip migration
+	if (selectedSettings && selectedSettings.length === 0) {
+		res.write('* Settings skipped (empty selection)\r\n\r\n');
+		return { response: 'Skipped', name: 'Settings' };
+	}
 
 	try {
 		const currentSettings = await client.request(readSettings());
-		const mergedSettings = customDefu(currentSettings, settings) as DirectusSettings;
+
+		// Issue #013: Filter settings if selectedSettings provided
+		let settingsToMerge = settings;
+		if (selectedSettings && selectedSettings.length > 0 && settings) {
+			const filteredSettings: Partial<Settings> = {};
+			for (const field of selectedSettings) {
+				if (field in settings) {
+					(filteredSettings as any)[field] = (settings as any)[field];
+				}
+			}
+			settingsToMerge = filteredSettings as Settings;
+			res.write(`* Filtering to ${selectedSettings.length} selected field(s): ${selectedSettings.join(', ')}\r\n\r\n`);
+		}
+
+		const mergedSettings = customDefu(settingsToMerge, currentSettings) as DirectusSettings;
 
 		if (!dry_run) {
 			await client.request(updateSettings(mergedSettings));

--- a/packages/migration-bundle/src/migration-endpoint/composables/migrate-translations.ts
+++ b/packages/migration-bundle/src/migration-endpoint/composables/migrate-translations.ts
@@ -3,17 +3,57 @@ import type { DirectusError, Translation } from '../../types/extension';
 import type { Schema } from '../api';
 import { createTranslations, readTranslations } from '@directus/sdk';
 
-async function migrateTranslations({ res, client, translations, dry_run = false }: { res: any; client: RestClient<Schema>; translations: Translation[] | null; dry_run: boolean }): Promise<{ response: string; name: string } | DirectusError> {
+async function migrateTranslations({
+	res,
+	client,
+	translations,
+	selectedLanguages,
+	translationKeyPattern,
+	dry_run = false,
+}: {
+	res: any;
+	client: RestClient<Schema>;
+	translations: Translation[] | null;
+	selectedLanguages?: string[];
+	translationKeyPattern?: string;
+	dry_run: boolean;
+}): Promise<{ response: string; name: string } | DirectusError> {
 	if (!translations) {
 		res.write('* Couldn\'t read data from extract\r\n\r\n');
 		return { name: 'Directus Error', status: 404, errors: [{ message: 'No translations found' }] };
 	}
-	else if (translations.length === 0) {
-		res.write('* No Translations to migrate\r\n\r\n');
+
+	// Issue #013: Handle empty language selection = skip migration
+	if (selectedLanguages && selectedLanguages.length === 0) {
+		res.write('* Translations skipped (empty language selection)\r\n\r\n');
+		return { response: 'Skipped', name: 'Translations' };
+	}
+
+	// Issue #013: Filter by selected languages
+	let filteredTranslations = translations;
+	if (selectedLanguages && selectedLanguages.length > 0) {
+		filteredTranslations = translations.filter((t) => selectedLanguages.includes(t.language));
+		res.write(`* Filtering to languages: ${selectedLanguages.join(', ')}\r\n\r\n`);
+	}
+
+	// Issue #013: Filter by key pattern
+	if (translationKeyPattern) {
+		try {
+			const regex = new RegExp(translationKeyPattern);
+			filteredTranslations = filteredTranslations.filter((t) => regex.test(t.key));
+			res.write(`* Filtering by key pattern: ${translationKeyPattern}\r\n\r\n`);
+		}
+		catch (e) {
+			res.write(`* Invalid key pattern regex: ${translationKeyPattern}\r\n\r\n`);
+		}
+	}
+
+	if (filteredTranslations.length === 0) {
+		res.write('* No Translations match filter criteria\r\n\r\n');
 		return { response: 'Empty', name: 'Translations' };
 	}
 
-	res.write(`* [Local] Found ${translations.length} translations\r\n\r\n`);
+	res.write(`* [Local] Found ${filteredTranslations.length} translations (filtered from ${translations.length})\r\n\r\n`);
 
 	try {
 		// Fetch existing translations
@@ -23,7 +63,7 @@ async function migrateTranslations({ res, client, translations, dry_run = false 
 
 		const existingTranslationKeys = new Set(existingTranslations.map((t) => `${t.language}_${t.key}`));
 
-		const newTranslations = translations.filter((t) => {
+		const newTranslations = filteredTranslations.filter((t) => {
 			const key = `${t.language}_${t.key}`;
 
 			if (existingTranslationKeys.has(key)) {

--- a/packages/migration-bundle/src/migration-endpoint/index.ts
+++ b/packages/migration-bundle/src/migration-endpoint/index.ts
@@ -427,19 +427,6 @@ export default defineEndpoint({
 								const content_response = await migrateData({ res, client, fullData: dataFetch.fullData, singletons: dataFetch.singletons, dry_run: isDryRun });
 								const contentMigrationValid = await validate_migration([content_response]);
 								res.write(contentMigrationValid ? `</div><h3 class="done">${Icon} Collections Migrated</h3>\r\n\r\n` : `</div><h3 class="error">${Icon} Collections Migration Failed</h3>\r\n\r\n`);
-
-								if (contentMigrationValid) {
-									// Step 2.6: Comments
-									if (scope.comments) {
-										res.write(`<div class="pending"><h3>${spinner} Migrating Comments</h3>\r\n\r\n`);
-										const comments_response = await migrateComments({ res, client, comments: systemFetch.comments, dry_run: isDryRun });
-										const commentsMigrationValid = await validate_migration([comments_response]);
-										res.write(commentsMigrationValid ? `</div><h3 class="done">${Icon} Comments Migrated</h3>\r\n\r\n` : `</div><h3 class="error">${Icon} Comments Migration Failed</h3>\r\n\r\n`);
-									}
-									else {
-										res.write(`<h3 class="skipped">${Icon} Comments Skipped</h3>\r\n\r\n`);
-									}
-								}
 							}
 
 							// Step 2.7: Required Fields
@@ -450,6 +437,17 @@ export default defineEndpoint({
 						}
 						else {
 							res.write(`<h3 class="skipped">${Icon} Content Skipped</h3>\r\n\r\n`);
+						}
+
+						// Step 2.6: Comments (standalone - not dependent on content)
+						if (scope.comments) {
+							res.write(`<div class="pending"><h3>${spinner} Migrating Comments</h3>\r\n\r\n`);
+							const comments_response = await migrateComments({ res, client, comments: systemFetch.comments, dry_run: isDryRun });
+							const commentsMigrationValid = await validate_migration([comments_response]);
+							res.write(commentsMigrationValid ? `</div><h3 class="done">${Icon} Comments Migrated</h3>\r\n\r\n` : `</div><h3 class="error">${Icon} Comments Migration Failed</h3>\r\n\r\n`);
+						}
+						else {
+							res.write(`<h3 class="skipped">${Icon} Comments Skipped</h3>\r\n\r\n`);
 						}
 
 						// Step 2.7: Dashboards

--- a/packages/migration-bundle/src/migration-endpoint/index.ts
+++ b/packages/migration-bundle/src/migration-endpoint/index.ts
@@ -453,8 +453,8 @@ export default defineEndpoint({
 						// Step 2.7: Dashboards
 						if (scope.dashboards) {
 							res.write(`<div class="pending"><h3>${spinner} Migrating Insights</h3>\r\n\r\n`);
-							const dashboard_response = await migrateDashboards({ res, client, dashboards: systemFetch.dashboards, dry_run: isDryRun });
-							const panel_response = await migratePanels({ res, client, panels: systemFetch.panels, dry_run: isDryRun });
+							const dashboard_response = await migrateDashboards({ res, client, dashboards: systemFetch.dashboards, selectedDashboards: scope.selectedDashboards, dry_run: isDryRun });
+							const panel_response = await migratePanels({ res, client, panels: systemFetch.panels, selectedDashboards: scope.selectedDashboards, dry_run: isDryRun });
 							const insightsMigrationValid = await validate_migration([dashboard_response, panel_response]);
 							res.write(insightsMigrationValid ? `</div><h3 class="done">${Icon} Insights Migrated</h3>\r\n\r\n` : `</div><h3 class="error">${Icon} Insights Migration Failed</h3>\r\n\r\n`);
 						}
@@ -495,10 +495,10 @@ export default defineEndpoint({
 							res.write(`<h3 class="skipped">${Icon} Translations Skipped</h3>\r\n\r\n`);
 						}
 
-						// Step 2.11: Translations
+						// Step 2.11: Presets
 						if (scope.presets) {
 							res.write(`<div class="pending"><h3>${spinner} Migrating Presets</h3>\r\n\r\n`);
-							const presets_response = await migratePresets({ res, client, presets: systemFetch.presets, dry_run: isDryRun });
+							const presets_response = await migratePresets({ res, client, presets: systemFetch.presets, selectedPresets: scope.selectedPresets, dry_run: isDryRun });
 							const presetsMigrationValid = await validate_migration([presets_response]);
 							res.write(presetsMigrationValid ? `</div><h3 class="done">${Icon} Presets Migrated</h3>\r\n\r\n` : `</div><h3 class="error">${Icon} Presets Migration Failed</h3>\r\n\r\n`);
 						}

--- a/packages/migration-bundle/src/migration-endpoint/index.ts
+++ b/packages/migration-bundle/src/migration-endpoint/index.ts
@@ -323,22 +323,62 @@ export default defineEndpoint({
 
 					// Continue with other migrations if schema succeeded or was skipped
 					if (schemaMigrationOk) {
-						// Step 2.2: Users
+						// Step 2.2: Users (with granular options)
 						if (scope.users) {
 							res.write(`<div class="pending"><h3>${spinner} Migrating Users</h3>\r\n\r\n`);
-							const role_response = await migrateRoles({ res, client, roles: systemFetch.roles, dry_run: isDryRun });
-							const policy_response = await migratePolicies({ res, client, policies: systemFetch.policies, dry_run: isDryRun });
-							const permission_response = await migratePermissions({ res, client, permissions: systemFetch.permissions, dry_run: isDryRun });
-							const user_response = await migrateUsers({ res, client, users: systemFetch.users, roles: systemFetch.roles, dry_run: isDryRun });
-							const access_response = await migrateAccess({ res, client, access: systemFetch.access, roles: systemFetch.roles, dry_run: isDryRun });
 
-							const userMigrationValid = await validate_migration([
-								role_response,
-								policy_response,
-								permission_response,
-								user_response,
-								access_response,
-							]);
+							// Get granular options with defaults
+							const granular = scope.usersGranular || {
+								roles: true,
+								policies: true,
+								permissions: true,
+								userAccounts: true,
+								access: true,
+							};
+
+							const migrationResponses = [];
+
+							if (granular.roles) {
+								const role_response = await migrateRoles({ res, client, roles: systemFetch.roles, dry_run: isDryRun });
+								migrationResponses.push(role_response);
+							}
+							else {
+								res.write('* Skipping roles\r\n');
+							}
+
+							if (granular.policies) {
+								const policy_response = await migratePolicies({ res, client, policies: systemFetch.policies, dry_run: isDryRun });
+								migrationResponses.push(policy_response);
+							}
+							else {
+								res.write('* Skipping policies\r\n');
+							}
+
+							if (granular.permissions) {
+								const permission_response = await migratePermissions({ res, client, permissions: systemFetch.permissions, dry_run: isDryRun });
+								migrationResponses.push(permission_response);
+							}
+							else {
+								res.write('* Skipping permissions\r\n');
+							}
+
+							if (granular.userAccounts) {
+								const user_response = await migrateUsers({ res, client, users: systemFetch.users, roles: systemFetch.roles, dry_run: isDryRun });
+								migrationResponses.push(user_response);
+							}
+							else {
+								res.write('* Skipping user accounts\r\n');
+							}
+
+							if (granular.access) {
+								const access_response = await migrateAccess({ res, client, access: systemFetch.access, roles: systemFetch.roles, dry_run: isDryRun });
+								migrationResponses.push(access_response);
+							}
+							else {
+								res.write('* Skipping access rules\r\n');
+							}
+
+							const userMigrationValid = await validate_migration(migrationResponses);
 
 							res.write(userMigrationValid ? `</div><h3 class="done">${Icon} Users Migrated</h3>\r\n\r\n` : `</div><h3 class="error">${Icon} Users Migration Failed</h3>\r\n\r\n`);
 						}
@@ -346,13 +386,11 @@ export default defineEndpoint({
 							res.write(`<h3 class="skipped">${Icon} Users Skipped</h3>\r\n\r\n`);
 						}
 
-						if (scope.content) {
-							res.write(`<div class="pending"><h3>${spinner} Removing Field Requirements</h3>\r\n\r\n`);
-							const field_response = await updateRequiredFields({ res, client, service: fieldService, collections: dataFetch.collections, dry_run: isDryRun, task: 'remove' });
-							const fieldUpdateValid = await validate_migration([field_response]);
-							res.write(fieldUpdateValid ? `</div><h3 class="done">${Icon} Field Requirements Removed</h3>\r\n\r\n` : `</div><h3 class="error">${Icon} Failed to Remove Field Requirements</h3>\r\n\r\n`);
+						// Step 2.3: Files (now separate from content)
+						// For backward compatibility: if content is selected but files is not explicitly set, include files
+						const shouldMigrateFiles = scope.files === true || (scope.content && scope.files !== false);
 
-							// Step 2.3: Files
+						if (shouldMigrateFiles) {
 							res.write(`<div class="pending"><h3>${spinner} Migrating Files</h3>\r\n\r\n`);
 							const folder_response = await migrateFolders({ res, client, folders: systemFetch.folders, dry_run: isDryRun });
 							const file_response = await migrateFiles({ res, client, service: assetService, files: dataFetch.files, dry_run: isDryRun });
@@ -363,21 +401,40 @@ export default defineEndpoint({
 							]);
 
 							res.write(fileMigrationValid ? `</div><h3 class="done">${Icon} Files Migrated</h3>\r\n\r\n` : `</div><h3 class="error">${Icon} Files Migration Partially Failed</h3>\r\n\r\n`);
+						}
+						else {
+							res.write(`<h3 class="skipped">${Icon} Files Skipped</h3>\r\n\r\n`);
+						}
+
+						// Step 2.3b: Folders Only (when folders enabled but files not migrating)
+						if (scope.folders && !shouldMigrateFiles) {
+							res.write(`<div class="pending"><h3>${spinner} Migrating Folders</h3>\r\n\r\n`);
+							const folder_response = await migrateFolders({ res, client, folders: systemFetch.folders, dry_run: isDryRun });
+							const folderMigrationValid = await validate_migration([folder_response]);
+							res.write(folderMigrationValid ? `</div><h3 class="done">${Icon} Folders Migrated</h3>\r\n\r\n` : `</div><h3 class="error">${Icon} Folders Migration Failed</h3>\r\n\r\n`);
+						}
+
+						// Step 2.4: Content
+						if (scope.content) {
+							res.write(`<div class="pending"><h3>${spinner} Removing Field Requirements</h3>\r\n\r\n`);
+							const field_response = await updateRequiredFields({ res, client, service: fieldService, collections: dataFetch.collections, dry_run: isDryRun, task: 'remove' });
+							const fieldUpdateValid = await validate_migration([field_response]);
+							res.write(fieldUpdateValid ? `</div><h3 class="done">${Icon} Field Requirements Removed</h3>\r\n\r\n` : `</div><h3 class="error">${Icon} Failed to Remove Field Requirements</h3>\r\n\r\n`);
 
 							if (fieldUpdateValid) {
-								// Step 2.4: Data
+								// Step 2.5: Data
 								res.write(`<div class="pending"><h3>${spinner} Migrating Collections</h3>\r\n\r\n`);
 								const content_response = await migrateData({ res, client, fullData: dataFetch.fullData, singletons: dataFetch.singletons, dry_run: isDryRun });
 								const contentMigrationValid = await validate_migration([content_response]);
 								res.write(contentMigrationValid ? `</div><h3 class="done">${Icon} Collections Migrated</h3>\r\n\r\n` : `</div><h3 class="error">${Icon} Collections Migration Failed</h3>\r\n\r\n`);
 
 								if (contentMigrationValid) {
-									// Step 2.5: Comments
+									// Step 2.6: Comments
 									if (scope.comments) {
 										res.write(`<div class="pending"><h3>${spinner} Migrating Comments</h3>\r\n\r\n`);
 										const comments_response = await migrateComments({ res, client, comments: systemFetch.comments, dry_run: isDryRun });
-										const contentMigrationValid = await validate_migration([comments_response]);
-										res.write(contentMigrationValid ? `</div><h3 class="done">${Icon} Comments Migrated</h3>\r\n\r\n` : `</div><h3 class="error">${Icon} Comments Migration Failed</h3>\r\n\r\n`);
+										const commentsMigrationValid = await validate_migration([comments_response]);
+										res.write(commentsMigrationValid ? `</div><h3 class="done">${Icon} Comments Migrated</h3>\r\n\r\n` : `</div><h3 class="error">${Icon} Comments Migration Failed</h3>\r\n\r\n`);
 									}
 									else {
 										res.write(`<h3 class="skipped">${Icon} Comments Skipped</h3>\r\n\r\n`);
@@ -385,7 +442,7 @@ export default defineEndpoint({
 								}
 							}
 
-							// Step 2.6: Required Fields
+							// Step 2.7: Required Fields
 							res.write(`<div class="pending"><h3>${spinner} Updating Required Fields</h3>\r\n\r\n`);
 							const fields_response = await updateRequiredFields({ res, client, service: fieldService, collections: dataFetch.collections, dry_run: isDryRun, task: 'add' });
 							const fieldsUpdateValid = await validate_migration([fields_response]);
@@ -419,16 +476,26 @@ export default defineEndpoint({
 						}
 
 						// Step 2.9: Settings
-						res.write(`<div class="pending"><h3>${spinner} Migrating Settings</h3>\r\n\r\n`);
-						const settings_response = await migrateSettings({ res, client, settings: systemFetch.settings, dry_run: isDryRun });
-						const settingsMigrationValid = await validate_migration([settings_response]);
-						res.write(settingsMigrationValid ? `</div><h3 class="done">${Icon} Settings Migrated</h3>\r\n\r\n` : `</div><h3 class="error">${Icon} Settings Migration Failed</h3>\r\n\r\n`);
+						if (scope.settings !== false) {
+							res.write(`<div class="pending"><h3>${spinner} Migrating Settings</h3>\r\n\r\n`);
+							const settings_response = await migrateSettings({ res, client, settings: systemFetch.settings, dry_run: isDryRun });
+							const settingsMigrationValid = await validate_migration([settings_response]);
+							res.write(settingsMigrationValid ? `</div><h3 class="done">${Icon} Settings Migrated</h3>\r\n\r\n` : `</div><h3 class="error">${Icon} Settings Migration Failed</h3>\r\n\r\n`);
+						}
+						else {
+							res.write(`<h3 class="skipped">${Icon} Settings Skipped</h3>\r\n\r\n`);
+						}
 
 						// Step 2.10: Translations
-						res.write(`<div class="pending"><h3>${spinner} Migrating Translations</h3>\r\n\r\n`);
-						const translations_response = await migrateTranslations({ res, client, translations: systemFetch.translations, dry_run: isDryRun });
-						const translationsMigrationValid = await validate_migration([translations_response]);
-						res.write(translationsMigrationValid ? `</div><h3 class="done">${Icon} Translations Migrated</h3>\r\n\r\n` : `</div><h3 class="error">${Icon} Translations Migration Failed</h3>\r\n\r\n`);
+						if (scope.translations !== false) {
+							res.write(`<div class="pending"><h3>${spinner} Migrating Translations</h3>\r\n\r\n`);
+							const translations_response = await migrateTranslations({ res, client, translations: systemFetch.translations, dry_run: isDryRun });
+							const translationsMigrationValid = await validate_migration([translations_response]);
+							res.write(translationsMigrationValid ? `</div><h3 class="done">${Icon} Translations Migrated</h3>\r\n\r\n` : `</div><h3 class="error">${Icon} Translations Migration Failed</h3>\r\n\r\n`);
+						}
+						else {
+							res.write(`<h3 class="skipped">${Icon} Translations Skipped</h3>\r\n\r\n`);
+						}
 
 						// Step 2.11: Translations
 						if (scope.presets) {

--- a/packages/migration-bundle/src/migration-endpoint/index.ts
+++ b/packages/migration-bundle/src/migration-endpoint/index.ts
@@ -4,6 +4,7 @@ import { ForbiddenError } from '@directus/errors';
 import { defineEndpoint } from '@directus/extensions-sdk';
 import { createDirectus, rest, staticToken } from '@directus/sdk';
 import { toArray } from '@directus/utils';
+import { filterSchema } from '../utils/filter-schema';
 import notifyUser from '../utils/notify-user';
 import saveToFile from '../utils/save-file';
 import { validate_data, validate_migration, validate_system } from '../utils/validate';
@@ -61,6 +62,13 @@ export default defineEndpoint({
 					token: env.MIGRATION_BUNDLE_DEFAULT_TOKEN || '',
 					options: env.MIGRATION_BUNDLE_DEFAULT_OPTIONS
 						? String(env.MIGRATION_BUNDLE_DEFAULT_OPTIONS).split(',').map((s: string) => s.trim())
+						: [],
+					// Collection-level filtering from environment variables
+					selectedCollections: env.MIGRATION_BUNDLE_SELECTED_COLLECTIONS
+						? String(env.MIGRATION_BUNDLE_SELECTED_COLLECTIONS).split(',').map((s: string) => s.trim())
+						: [],
+					excludedCollections: env.MIGRATION_BUNDLE_EXCLUDED_COLLECTIONS
+						? String(env.MIGRATION_BUNDLE_EXCLUDED_COLLECTIONS).split(',').map((s: string) => s.trim())
 						: [],
 				};
 				res.json(defaults);
@@ -248,7 +256,9 @@ export default defineEndpoint({
 				try {
 					// Step 1.1: Schema
 					res.write(`<div class="pending"><h3>${spinner} Creating Schema Snapshot</h3>\r\n\r\n`);
-					const currentSchema = await schemaService.snapshot();
+					const fullSchema = await schemaService.snapshot();
+					// Apply collection filtering to schema if specified
+					const currentSchema = scope.schema ? filterSchema(fullSchema, scope) : fullSchema;
 					await saveToFile(currentSchema, 'schema', fileService, folder, storage);
 					res.write(`</div><h3 class="done">${Icon} Schema Snapshot Created</h3>\r\n\r\n`);
 
@@ -289,19 +299,30 @@ export default defineEndpoint({
 
 					// Step 2: Migration
 					res.write(isDryRun ? '## Checking Destination\r\n\r\n' : '## Starting Migration\r\n\r\n');
-					// Step 2.1 Schema
-					res.write(`<div class="pending"><h3>${spinner} Applying Schema</h3>\r\n\r\n`);
-					const response = await migrateSchema({ res, client, schema: currentSchema, dry_run: isDryRun, force: scope.force }); // Can be { status: 204 } if there is no change
 
-					if ('errors' in response) {
-						const message = Array.isArray(response.errors) && response.errors.length > 0 ? response.errors[0]?.message : 'Unknown';
-						await notifyUser(notificationService, accountability, response);
-						res.write(`</div><h3 class="error">${Icon} Schema Failed to Apply</h3>\r\n\r\n`);
-						res.write(`Error Occurred: ${message}\r\n\r\n`);
+					// Step 2.1 Schema (conditional)
+					let schemaMigrationOk = true;
+					if (scope.schema) {
+						res.write(`<div class="pending"><h3>${spinner} Applying Schema</h3>\r\n\r\n`);
+						const response = await migrateSchema({ res, client, schema: currentSchema, dry_run: isDryRun, force: scope.force }); // Can be { status: 204 } if there is no change
+
+						if ('errors' in response) {
+							const message = Array.isArray(response.errors) && response.errors.length > 0 ? response.errors[0]?.message : 'Unknown';
+							await notifyUser(notificationService, accountability, response);
+							res.write(`</div><h3 class="error">${Icon} Schema Failed to Apply</h3>\r\n\r\n`);
+							res.write(`Error Occurred: ${message}\r\n\r\n`);
+							schemaMigrationOk = false;
+						}
+						else {
+							res.write(`</div><h3 class="done">${Icon} Schema Applied</h3>\r\n\r\n`);
+						}
 					}
 					else {
-						res.write(`</div><h3 class="done">${Icon} Schema Applied</h3>\r\n\r\n`);
+						res.write(`<h3 class="skipped">${Icon} Schema Skipped</h3>\r\n\r\n`);
+					}
 
+					// Continue with other migrations if schema succeeded or was skipped
+					if (schemaMigrationOk) {
 						// Step 2.2: Users
 						if (scope.users) {
 							res.write(`<div class="pending"><h3>${spinner} Migrating Users</h3>\r\n\r\n`);
@@ -430,7 +451,7 @@ export default defineEndpoint({
 						else {
 							res.write(`<h3 class="skipped">${Icon} Extensions Skipped</h3>\r\n\r\n`);
 						}
-					}
+					} // End of schemaMigrationOk block
 
 					res.write(`## Migration ${isDryRun ? 'Dry Run' : ''} Complete\r\n\r\n`);
 					res.write(`The files can be download from the [file library](/admin/files/folders/${folder}).\r\n\r\n`);

--- a/packages/migration-bundle/src/migration-endpoint/index.ts
+++ b/packages/migration-bundle/src/migration-endpoint/index.ts
@@ -476,7 +476,7 @@ export default defineEndpoint({
 						// Step 2.9: Settings
 						if (scope.settings !== false) {
 							res.write(`<div class="pending"><h3>${spinner} Migrating Settings</h3>\r\n\r\n`);
-							const settings_response = await migrateSettings({ res, client, settings: systemFetch.settings, dry_run: isDryRun });
+							const settings_response = await migrateSettings({ res, client, settings: systemFetch.settings, selectedSettings: scope.selectedSettings, dry_run: isDryRun });
 							const settingsMigrationValid = await validate_migration([settings_response]);
 							res.write(settingsMigrationValid ? `</div><h3 class="done">${Icon} Settings Migrated</h3>\r\n\r\n` : `</div><h3 class="error">${Icon} Settings Migration Failed</h3>\r\n\r\n`);
 						}
@@ -487,7 +487,7 @@ export default defineEndpoint({
 						// Step 2.10: Translations
 						if (scope.translations !== false) {
 							res.write(`<div class="pending"><h3>${spinner} Migrating Translations</h3>\r\n\r\n`);
-							const translations_response = await migrateTranslations({ res, client, translations: systemFetch.translations, dry_run: isDryRun });
+							const translations_response = await migrateTranslations({ res, client, translations: systemFetch.translations, selectedLanguages: scope.selectedLanguages, translationKeyPattern: scope.translationKeyPattern, dry_run: isDryRun });
 							const translationsMigrationValid = await validate_migration([translations_response]);
 							res.write(translationsMigrationValid ? `</div><h3 class="done">${Icon} Translations Migrated</h3>\r\n\r\n` : `</div><h3 class="error">${Icon} Translations Migration Failed</h3>\r\n\r\n`);
 						}

--- a/packages/migration-bundle/src/migration-module/module.vue
+++ b/packages/migration-bundle/src/migration-module/module.vue
@@ -204,6 +204,15 @@ export default defineComponent({
 		const selectedInsights = ref<string[]>([]);
 		const isLoadingInsights = ref<boolean>(false);
 
+		// Issue #009: Files filtering
+		const filesFilterMode = ref<'all' | 'selected'>('all');
+		const availableFolders = ref<Array<{ text: string; value: string }>>([]);
+		const selectedFolders = ref<string[]>([]);
+		const isLoadingFolders = ref<boolean>(false);
+
+		// Issue #009: Comments integration into Content tab
+		const includeCommentsForContent = ref<boolean>(true);
+
 		// Tab-based UI - active tab for granular options
 		const activeTab = ref<string[]>(['schema']);
 
@@ -215,7 +224,7 @@ export default defineComponent({
 			}
 			// Check if current tab is still valid
 			const currentTab = activeTab.value[0];
-			const tabOptions = ['schema', 'content', 'users', 'flows', 'extensions', 'settings', 'translations'];
+			const tabOptions = ['schema', 'content', 'files', 'users', 'presets', 'dashboards', 'flows', 'extensions', 'settings', 'translations'];
 			if (currentTab && selections.includes(currentTab as Options)) {
 				return; // Current tab is still valid
 			}
@@ -465,6 +474,44 @@ export default defineComponent({
 			}
 		};
 
+		// Issue #009: Load available folders
+		const loadFolders = async () => {
+			isLoadingFolders.value = true;
+			try {
+				const response = await api.get('/folders', {
+					params: {
+						fields: ['id', 'name', 'parent'],
+						limit: -1,
+					},
+				});
+				const foldersData = response.data.data || [];
+
+				// Build folder tree labels with parent path
+				const folderMap = new Map<string, any>();
+				foldersData.forEach((f: any) => folderMap.set(f.id, f));
+
+				const buildLabel = (folder: any): string => {
+					if (folder.parent && folderMap.has(folder.parent)) {
+						return `${buildLabel(folderMap.get(folder.parent))} / ${folder.name}`;
+					}
+					return folder.name;
+				};
+
+				availableFolders.value = foldersData
+					.map((f: any) => ({
+						text: buildLabel(f),
+						value: String(f.id),
+					}))
+					.sort((a: any, b: any) => a.text.localeCompare(b.text));
+			}
+			catch (error) {
+				console.error('Failed to load folders:', error);
+			}
+			finally {
+				isLoadingFolders.value = false;
+			}
+		};
+
 		// Load Users tab data when tab becomes active
 		watch(activeTab, (tab) => {
 			if (tab[0] === 'users' && availableRoles.value.length === 0) {
@@ -477,6 +524,10 @@ export default defineComponent({
 			// Issue #013: Load languages when Translations tab becomes active
 			if (tab[0] === 'translations' && availableLanguages.value.length === 0) {
 				loadLanguages();
+			}
+			// Issue #009: Load folders when Files tab becomes active
+			if (tab[0] === 'files' && availableFolders.value.length === 0) {
+				loadFolders();
 			}
 			// Issue #014: Load bookmarks when Bookmarks tab becomes active
 			if (tab[0] === 'presets' && availableBookmarks.value.length === 0) {
@@ -890,6 +941,16 @@ export default defineComponent({
 				extendedScope.selectedDashboards = selectedInsights.value;
 			}
 
+			// Issue #009: Add files/folders filtering to scope
+			if (scope.files && filesFilterMode.value === 'selected') {
+				extendedScope.selectedFolders = selectedFolders.value;
+			}
+
+			// Issue #009: Add comments integration to scope
+			if (scope.comments) {
+				extendedScope.includeCommentsForContent = includeCommentsForContent.value;
+			}
+
 			// Files defaults to true if content is selected (backward compatibility)
 			if (scope.content && !migrationOptionsSelections.value?.includes('files')) {
 				extendedScope.files = true;
@@ -999,6 +1060,13 @@ export default defineComponent({
 			availableInsights,
 			selectedInsights,
 			isLoadingInsights,
+			// Issue #009: Files filtering
+			filesFilterMode,
+			availableFolders,
+			selectedFolders,
+			isLoadingFolders,
+			// Issue #009: Comments integration
+			includeCommentsForContent,
 		};
 	},
 });
@@ -1154,6 +1222,13 @@ export default defineComponent({
 								Content
 							</v-tab>
 							<v-tab
+								v-if="migrationOptionsSelections?.includes('files')"
+								value="files"
+							>
+								<v-icon name="folder" small />
+								Files
+							</v-tab>
+							<v-tab
 								v-if="migrationOptionsSelections?.includes('users')"
 								value="users"
 							>
@@ -1306,21 +1381,76 @@ export default defineComponent({
 										Please select collections in the Schema tab first.
 									</v-notice>
 
-									<div class="content-files-section">
-										<h4>Files & Folders</h4>
-										<p class="tab-hint">Configure file migration options.</p>
-										<div class="files-checkboxes">
-											<v-checkbox
-												v-model="scope.files"
-												label="Include files"
-												:disabled="lockInterface"
-											/>
-											<v-checkbox
-												v-model="scope.folders"
-												label="Include folder structure"
-												:disabled="lockInterface"
-											/>
-										</div>
+									<!-- Comments Integration -->
+									<div v-if="migrationOptionsSelections?.includes('comments')" class="comments-integration">
+										<v-divider />
+										<h4>Comments</h4>
+										<v-checkbox
+											v-model="includeCommentsForContent"
+											label="Include comments for selected collections"
+											:disabled="lockInterface"
+										/>
+										<p class="tab-hint">
+											When enabled, only comments for the selected collections will be migrated.
+											When disabled, all comments will be migrated.
+										</p>
+									</div>
+								</div>
+							</v-tab-item>
+
+							<!-- Files Tab -->
+							<v-tab-item value="files">
+								<div class="tab-panel">
+									<h4>Files & Folders Filtering</h4>
+									<p class="tab-hint">Configure which files and folders to migrate.</p>
+
+									<div class="files-filter-mode">
+										<v-radio
+											v-model="filesFilterMode"
+											value="all"
+											label="All files and folders"
+											:disabled="lockInterface"
+										/>
+										<v-radio
+											v-model="filesFilterMode"
+											value="selected"
+											label="Selected folders only"
+											:disabled="lockInterface"
+										/>
+									</div>
+
+									<v-select
+										v-if="filesFilterMode === 'selected'"
+										v-model="selectedFolders"
+										:items="availableFolders"
+										:disabled="lockInterface || isLoadingFolders"
+										:loading="isLoadingFolders"
+										:multiple-preview-threshold="3"
+										item-text="label"
+										item-value="value"
+										placeholder="Select folders to include..."
+										multiple
+										class="tab-select"
+									>
+										<template #prepend>
+											<v-icon name="folder" />
+										</template>
+									</v-select>
+
+									<v-notice v-if="filesFilterMode === 'selected' && selectedFolders.length === 0" type="warning" class="tab-notice">
+										No folders selected. Files migration will be skipped.
+									</v-notice>
+
+									<v-notice v-else-if="filesFilterMode === 'all'" type="info" class="tab-notice">
+										All files and folders will be migrated.
+									</v-notice>
+
+									<div class="files-options">
+										<v-checkbox
+											v-model="scope.folders"
+											label="Include folder structure"
+											:disabled="lockInterface"
+										/>
 									</div>
 								</div>
 							</v-tab-item>
@@ -2131,6 +2261,8 @@ h3.skipped .icon i::after {
 
 .migration-tabs {
 	border-bottom: 2px solid var(--theme--border-color);
+	display: flex;
+	flex-wrap: wrap;
 }
 
 .migration-tabs .v-tab {
@@ -2208,19 +2340,45 @@ h3.skipped .icon i::after {
 	margin: 0;
 }
 
-.content-files-section {
-	margin-top: 24px;
-	padding-top: 20px;
+/* Issue #009: Comments integration on Content tab */
+.comments-integration {
+	margin-top: 20px;
+	padding-top: 16px;
+}
+
+.comments-integration h4 {
+	margin-bottom: 8px;
+}
+
+.comments-integration .v-checkbox {
+	margin: 0;
+}
+
+.comments-integration .tab-hint {
+	margin-top: 4px;
+	font-size: 12px;
+	color: var(--theme--foreground-subdued);
+}
+
+/* Issue #009: Files tab styling */
+.files-filter-mode {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	margin-bottom: 16px;
+}
+
+.files-filter-mode .v-radio {
+	margin: 0;
+}
+
+.files-options {
+	margin-top: 16px;
+	padding-top: 16px;
 	border-top: 1px solid var(--theme--border-color);
 }
 
-.files-checkboxes {
-	display: flex;
-	gap: 24px;
-	margin-top: 12px;
-}
-
-.files-checkboxes .v-checkbox {
+.files-options .v-checkbox {
 	margin: 0;
 }
 

--- a/packages/migration-bundle/src/migration-module/module.vue
+++ b/packages/migration-bundle/src/migration-module/module.vue
@@ -1,12 +1,12 @@
 <script lang="ts">
 import type { AxiosProgressEvent } from 'axios';
-import type { Payload } from '../types/extension';
+import type { Payload, UsersGranularOptions } from '../types/extension';
 import { useApi } from '@directus/extensions-sdk';
 import { computed, defineComponent, reactive, ref, watch } from 'vue';
 import { md } from '../utils/md';
 import SupportNavigation from './components/navigation.vue';
 
-type Options = 'schema' | 'content' | 'users' | 'comments' | 'presets' | 'dashboards' | 'extensions' | 'flows' | 'force';
+type Options = 'schema' | 'content' | 'files' | 'users' | 'comments' | 'presets' | 'dashboards' | 'extensions' | 'flows' | 'settings' | 'translations' | 'force';
 
 export default defineComponent({
 	components: {
@@ -59,6 +59,10 @@ export default defineComponent({
 				value: 'content',
 			},
 			{
+				label: 'Files',
+				value: 'files',
+			},
+			{
 				label: 'Users',
 				value: 'users',
 			},
@@ -82,19 +86,31 @@ export default defineComponent({
 				label: 'Flows',
 				value: 'flows',
 			},
+			{
+				label: 'Settings',
+				value: 'settings',
+			},
+			{
+				label: 'Translations',
+				value: 'translations',
+			},
 		]);
 
 		const migrationOptionsSelections = ref<Options[] | null>(migrationOptions.value.map((o) => o.value as Options));
 
-		const scope = reactive<Record<Options, boolean> & { selectedCollections?: string[]; excludedCollections?: string[]; contentCollections?: string[] }>({
+		const scope = reactive<Record<Options, boolean> & { selectedCollections?: string[]; excludedCollections?: string[]; contentCollections?: string[]; folders?: boolean }>({
 			schema: true,
 			users: false,
 			content: false,
+			files: true,  // Fix: Files checked by default
+			folders: true,
 			comments: false,
 			presets: false,
 			dashboards: false,
 			extensions: false,
 			flows: false,
+			settings: true,      // Default true for backward compatibility
+			translations: true,  // Default true for backward compatibility
 			force: false,
 		});
 
@@ -102,7 +118,7 @@ export default defineComponent({
 		const contentCollections = ref<string[]>([]);
 
 		// Fix 6.1: Show Force checkbox when partial migration is selected
-		const allMigrationOptions = ['schema', 'content', 'users', 'comments', 'presets', 'dashboards', 'extensions', 'flows'];
+		const allMigrationOptions = ['schema', 'content', 'files', 'users', 'comments', 'presets', 'dashboards', 'extensions', 'flows', 'settings', 'translations'];
 		const showForceCheckbox = computed(() => {
 			// Show if compatibility check suggests force
 			const forceInMessage = validationMessage.value?.message?.includes('force') || false;
@@ -113,6 +129,80 @@ export default defineComponent({
 
 			return forceInMessage || partialMigration;
 		});
+
+		// Users granular options
+		const usersGranular = reactive<UsersGranularOptions>({
+			roles: true,
+			policies: true,
+			permissions: true,
+			userAccounts: true,
+			access: true,
+		});
+
+		// Watch for users granular dependencies
+		watch(() => usersGranular.roles, (val) => {
+			if (!val) {
+				usersGranular.policies = false;
+				usersGranular.userAccounts = false;
+			}
+		});
+
+		watch(() => usersGranular.policies, (val) => {
+			if (!val) {
+				usersGranular.permissions = false;
+				usersGranular.access = false;
+			}
+		});
+
+		watch(() => usersGranular.userAccounts, (val) => {
+			if (!val) {
+				usersGranular.access = false;
+			}
+		});
+
+		// Selected flows and extensions for granular selection
+		const selectedFlows = ref<string[]>([]);
+		const selectedExtensions = ref<string[]>([]);
+		const availableFlows = ref<Array<{ id: string; name: string }>>([]);
+		const availableExtensions = ref<Array<{ name: string; bundle: string | null; source: 'registry' | 'local' }>>([]);
+
+		// Phase 6: Users tab - specific item selection
+		const availableRoles = ref<Array<{ id: string; name: string }>>([]);
+		const availablePolicies = ref<Array<{ id: string; name: string }>>([]);
+		const availablePermissions = ref<Array<{ id: number; policy: string; collection: string; action: string }>>([]);
+		const availableUsers = ref<Array<{ id: string; email: string; first_name: string; last_name: string; role: string }>>([]);
+		const availableAccessRules = ref<Array<{ id: number; role: string | null; user: string | null; policy: string }>>([]);
+
+		const selectedRoles = ref<string[]>([]);
+		const selectedPolicies = ref<string[]>([]);
+		const selectedPermissions = ref<number[]>([]);
+		const selectedUserAccounts = ref<string[]>([]);
+		const selectedAccessRules = ref<number[]>([]);
+
+		// Tab-based UI - active tab for granular options
+		const activeTab = ref<string[]>(['schema']);
+
+		// Auto-switch to first enabled tab when options change
+		watch(migrationOptionsSelections, (selections) => {
+			if (!selections || selections.length === 0) {
+				activeTab.value = [];
+				return;
+			}
+			// Check if current tab is still valid
+			const currentTab = activeTab.value[0];
+			const tabOptions = ['schema', 'content', 'users', 'flows', 'extensions'];
+			if (currentTab && selections.includes(currentTab as Options)) {
+				return; // Current tab is still valid
+			}
+			// Switch to first available tab
+			for (const tab of tabOptions) {
+				if (selections.includes(tab as Options)) {
+					activeTab.value = [tab];
+					return;
+				}
+			}
+			activeTab.value = [];
+		}, { immediate: true });
 
 		const api = useApi();
 
@@ -148,6 +238,101 @@ export default defineComponent({
 			}
 		};
 
+		// Phase 6: Load functions for Users tab items
+		const loadRoles = async () => {
+			try {
+				const response = await api.get('/roles', { params: { fields: ['id', 'name'], limit: -1 } });
+				availableRoles.value = response.data.data || [];
+			}
+			catch (error) {
+				console.error('Failed to load roles:', error);
+			}
+		};
+
+		const loadPolicies = async () => {
+			try {
+				const response = await api.get('/policies', { params: { fields: ['id', 'name'], limit: -1 } });
+				availablePolicies.value = response.data.data || [];
+			}
+			catch (error) {
+				console.error('Failed to load policies:', error);
+			}
+		};
+
+		const loadPermissions = async () => {
+			try {
+				const response = await api.get('/permissions', { params: { fields: ['id', 'policy', 'collection', 'action'], limit: -1 } });
+				availablePermissions.value = response.data.data || [];
+			}
+			catch (error) {
+				console.error('Failed to load permissions:', error);
+			}
+		};
+
+		const loadUserAccounts = async () => {
+			try {
+				const response = await api.get('/users', { params: { fields: ['id', 'email', 'first_name', 'last_name', 'role'], limit: -1 } });
+				availableUsers.value = response.data.data || [];
+			}
+			catch (error) {
+				console.error('Failed to load users:', error);
+			}
+		};
+
+		const loadAccessRules = async () => {
+			try {
+				const response = await api.get('/access', { params: { fields: ['id', 'role', 'user', 'policy'], limit: -1 } });
+				availableAccessRules.value = response.data.data || [];
+			}
+			catch (error) {
+				console.error('Failed to load access rules:', error);
+			}
+		};
+
+		const loadUsersTabData = async () => {
+			await Promise.all([
+				loadRoles(),
+				loadPolicies(),
+				loadPermissions(),
+				loadUserAccounts(),
+				loadAccessRules(),
+			]);
+		};
+
+		// Load Users tab data when tab becomes active
+		watch(activeTab, (tab) => {
+			if (tab[0] === 'users' && availableRoles.value.length === 0) {
+				loadUsersTabData();
+			}
+		});
+
+		// Phase 6: Auto-select dependencies when items are selected
+		// When user account is selected, auto-select their role
+		watch(selectedUserAccounts, (userIds) => {
+			if (userIds.length === 0) return;
+			const users = availableUsers.value.filter(u => userIds.includes(u.id));
+			const roleIds = [...new Set(users.map(u => u.role).filter(Boolean))] as string[];
+			roleIds.forEach(roleId => {
+				if (!selectedRoles.value.includes(roleId)) {
+					selectedRoles.value.push(roleId);
+				}
+			});
+		});
+
+		// When access rule is selected, auto-select role and policy
+		watch(selectedAccessRules, (accessIds) => {
+			if (accessIds.length === 0) return;
+			const accessItems = availableAccessRules.value.filter(a => accessIds.includes(a.id));
+			accessItems.forEach(access => {
+				if (access.role && !selectedRoles.value.includes(access.role)) {
+					selectedRoles.value.push(access.role);
+				}
+				if (access.policy && !selectedPolicies.value.includes(access.policy)) {
+					selectedPolicies.value.push(access.policy);
+				}
+			});
+		});
+
 		// Load ENV defaults
 		const loadEnvDefaults = async () => {
 			try {
@@ -164,6 +349,10 @@ export default defineComponent({
 					// Fix 3.2: Ensure 'schema' is always included in options
 					if (!options.includes('schema')) {
 						options = ['schema', ...options];
+					}
+					// Fix: Ensure 'files' is always included in options (backward compatibility)
+					if (!options.includes('files')) {
+						options = [...options, 'files'];
 					}
 					migrationOptionsSelections.value = options;
 				}
@@ -215,6 +404,10 @@ export default defineComponent({
 				let selectedOptions = options.selectedOptions || [];
 				if (!selectedOptions.includes('schema')) {
 					selectedOptions = ['schema', ...selectedOptions];
+				}
+				// Fix: Ensure 'files' is always included in preset options (backward compatibility)
+				if (!selectedOptions.includes('files')) {
+					selectedOptions = [...selectedOptions, 'files'];
 				}
 				migrationOptionsSelections.value = selectedOptions;
 
@@ -321,6 +514,27 @@ export default defineComponent({
 		// Initialize on mount
 		initialize();
 
+		// Fetch available flows and extensions
+		const fetchAvailableData = async () => {
+			try {
+				const [flowsResponse, extensionsResponse] = await Promise.all([
+					api.get('/flows', { params: { fields: ['id', 'name'], limit: -1 } }),
+					api.get('/extensions'),
+				]);
+				availableFlows.value = flowsResponse.data.data || [];
+				availableExtensions.value = (extensionsResponse.data.data || []).map((ext: any) => ({
+					name: ext.schema?.name || ext.id,
+					bundle: ext.bundle,
+					source: ext.meta?.source || 'local',
+				}));
+			}
+			catch (error) {
+				console.warn('Failed to fetch flows/extensions:', error);
+			}
+		};
+
+		fetchAvailableData();
+
 		// Update preset
 		const updatePreset = async () => {
 			if (!selectedPresetId.value || selectedPresetId.value === null) return;
@@ -401,29 +615,64 @@ export default defineComponent({
 
 			scope.force = forceSchema.value;
 
+			// Build extended scope with collection filtering and granular options
+			const extendedScope: Record<string, any> = { ...scope };
+
 			// Add collection-level filtering to scope
 			if (collectionFilterMode.value === 'include' && selectedCollections.value.length > 0) {
-				scope.selectedCollections = selectedCollections.value;
-				delete scope.excludedCollections;
+				extendedScope.selectedCollections = selectedCollections.value;
 			}
 			else if (collectionFilterMode.value === 'exclude' && excludedCollections.value.length > 0) {
-				scope.excludedCollections = excludedCollections.value;
-				delete scope.selectedCollections;
-			}
-			else {
-				delete scope.selectedCollections;
-				delete scope.excludedCollections;
+				extendedScope.excludedCollections = excludedCollections.value;
 			}
 
 			// Add content-specific collection selection
 			if (contentCollections.value.length > 0) {
-				scope.contentCollections = contentCollections.value;
-			}
-			else {
-				delete scope.contentCollections;
+				extendedScope.contentCollections = contentCollections.value;
 			}
 
-			response.value = await api.post(`/migration/${dryRun ? 'dry-run' : 'run'}`, { baseURL, token, scope }, {
+			// Add users granular options if users is selected
+			if (scope.users) {
+				extendedScope.usersGranular = { ...usersGranular };
+
+				// Phase 6: Add users selection options
+				const usersSelection: Record<string, any> = {};
+				if (selectedRoles.value.length > 0) {
+					usersSelection.selectedRoles = selectedRoles.value;
+				}
+				if (selectedPolicies.value.length > 0) {
+					usersSelection.selectedPolicies = selectedPolicies.value;
+				}
+				if (selectedPermissions.value.length > 0) {
+					usersSelection.selectedPermissions = selectedPermissions.value;
+				}
+				if (selectedUserAccounts.value.length > 0) {
+					usersSelection.selectedUsers = selectedUserAccounts.value;
+				}
+				if (selectedAccessRules.value.length > 0) {
+					usersSelection.selectedAccess = selectedAccessRules.value;
+				}
+				if (Object.keys(usersSelection).length > 0) {
+					extendedScope.usersSelection = usersSelection;
+				}
+			}
+
+			// Add selected flows if flows is selected and specific flows are chosen
+			if (scope.flows && selectedFlows.value.length > 0) {
+				extendedScope.selectedFlows = selectedFlows.value;
+			}
+
+			// Add selected extensions if extensions is selected and specific ones are chosen
+			if (scope.extensions && selectedExtensions.value.length > 0) {
+				extendedScope.selectedExtensions = selectedExtensions.value;
+			}
+
+			// Files defaults to true if content is selected (backward compatibility)
+			if (scope.content && !migrationOptionsSelections.value?.includes('files')) {
+				extendedScope.files = true;
+			}
+
+			response.value = await api.post(`/migration/${dryRun ? 'dry-run' : 'run'}`, { baseURL, token, scope: extendedScope }, {
 				onDownloadProgress: (progressEvent: AxiosProgressEvent) => {
 					let eventObj: XMLHttpRequest | undefined;
 
@@ -487,6 +736,25 @@ export default defineComponent({
 			contentCollections,
 			// Fix 6.1: Force checkbox visibility
 			showForceCheckbox,
+			// Granular options
+			usersGranular,
+			selectedFlows,
+			selectedExtensions,
+			availableFlows,
+			availableExtensions,
+			// Tab-based UI
+			activeTab,
+			// Phase 6: Users tab specific item selection
+			availableRoles,
+			availablePolicies,
+			availablePermissions,
+			availableUsers,
+			availableAccessRules,
+			selectedRoles,
+			selectedPolicies,
+			selectedPermissions,
+			selectedUserAccounts,
+			selectedAccessRules,
 		};
 	},
 });
@@ -624,80 +892,357 @@ export default defineComponent({
 						</v-button>
 					</div>
 
-					<!-- Collection-level filtering (shown when Schema OR Content is selected) -->
-					<div v-if="(forceSchema || (validationMessage && validationMessage.status === 'success')) && (migrationOptionsSelections?.includes('schema') || migrationOptionsSelections?.includes('content'))" class="migration-collection-filter">
-						<div class="collection-filter-header">
-							<v-icon name="filter_list" />
-							<span>Schema Collection Filter</span>
-							<v-select
-								v-model="collectionFilterMode"
-								:items="[
-									{ text: 'All Collections', value: 'all' },
-									{ text: 'Include Only', value: 'include' },
-									{ text: 'Exclude', value: 'exclude' },
-								]"
-								:disabled="lockInterface || isLoadingCollections"
-								placeholder="Filter Mode"
-							/>
-						</div>
-						<div v-if="collectionFilterMode === 'include'" class="collection-select">
-							<v-select
-								v-model="selectedCollections"
-								:items="availableCollections"
-								:disabled="lockInterface || isLoadingCollections"
-								:loading="isLoadingCollections"
-								:multiple-preview-threshold="2"
-								item-text="label"
-								item-value="value"
-								placeholder="Select collections for schema migration..."
-								multiple
+					<!-- Tab-based Granular Options -->
+					<div v-if="(forceSchema || (validationMessage && validationMessage.status === 'success')) && migrationOptionsSelections && migrationOptionsSelections.length > 0" class="migration-tabs-container">
+						<v-tabs v-model="activeTab" class="migration-tabs">
+							<v-tab
+								v-if="migrationOptionsSelections?.includes('schema')"
+								value="schema"
 							>
-								<template #prepend>
-									<v-icon name="add_circle" />
-								</template>
-							</v-select>
-						</div>
-						<div v-if="collectionFilterMode === 'exclude'" class="collection-select">
-							<v-select
-								v-model="excludedCollections"
-								:items="availableCollections"
-								:disabled="lockInterface || isLoadingCollections"
-								:loading="isLoadingCollections"
-								:multiple-preview-threshold="2"
-								item-text="label"
-								item-value="value"
-								placeholder="Select collections to exclude..."
-								multiple
+								<v-icon name="schema" small />
+								Schema
+							</v-tab>
+							<v-tab
+								v-if="migrationOptionsSelections?.includes('content')"
+								value="content"
 							>
-								<template #prepend>
-									<v-icon name="remove_circle" />
-								</template>
-							</v-select>
-						</div>
+								<v-icon name="table_rows" small />
+								Content
+							</v-tab>
+							<v-tab
+								v-if="migrationOptionsSelections?.includes('users')"
+								value="users"
+							>
+								<v-icon name="people" small />
+								Users
+							</v-tab>
+							<v-tab
+								v-if="migrationOptionsSelections?.includes('flows')"
+								value="flows"
+							>
+								<v-icon name="bolt" small />
+								Flows
+							</v-tab>
+							<v-tab
+								v-if="migrationOptionsSelections?.includes('extensions')"
+								value="extensions"
+							>
+								<v-icon name="extension" small />
+								Extensions
+							</v-tab>
+						</v-tabs>
 
-						<!-- Content collection selection (only when Content is selected AND collections are filtered) -->
-						<div v-if="migrationOptionsSelections?.includes('content') && collectionFilterMode === 'include' && selectedCollections.length > 0" class="content-collection-select">
-							<div class="collection-filter-header">
-								<v-icon name="storage" />
-								<span>Content Data Selection</span>
-							</div>
-							<v-select
-								v-model="contentCollections"
-								:items="availableCollections.filter(c => selectedCollections.includes(c.value))"
-								:disabled="lockInterface || isLoadingCollections"
-								:loading="isLoadingCollections"
-								:multiple-preview-threshold="2"
-								item-text="label"
-								item-value="value"
-								placeholder="Select which collections should have data migrated..."
-								multiple
-							>
-								<template #prepend>
-									<v-icon name="table_rows" />
-								</template>
-							</v-select>
-							<p class="content-hint">Only data from selected collections will be migrated. Leave empty to migrate all schema-selected collections' data.</p>
-						</div>
+						<v-tabs-items v-model="activeTab" class="migration-tab-content">
+							<!-- Schema Tab -->
+							<v-tab-item value="schema">
+								<div class="tab-panel">
+									<h4>Schema Collection Filtering</h4>
+									<p class="tab-hint">Select which collections to include in schema migration.</p>
+
+									<div class="filter-mode-selector">
+										<v-radio
+											v-model="collectionFilterMode"
+											value="all"
+											label="All collections"
+											:disabled="lockInterface"
+										/>
+										<v-radio
+											v-model="collectionFilterMode"
+											value="include"
+											label="Include specific collections"
+											:disabled="lockInterface"
+										/>
+										<v-radio
+											v-model="collectionFilterMode"
+											value="exclude"
+											label="Exclude specific collections"
+											:disabled="lockInterface"
+										/>
+									</div>
+
+									<v-select
+										v-if="collectionFilterMode === 'include'"
+										v-model="selectedCollections"
+										:items="availableCollections"
+										:disabled="lockInterface || isLoadingCollections"
+										:loading="isLoadingCollections"
+										:multiple-preview-threshold="2"
+										item-text="label"
+										item-value="value"
+										placeholder="Select collections to include..."
+										multiple
+										class="tab-select"
+									>
+										<template #prepend>
+											<v-icon name="add_circle" />
+										</template>
+									</v-select>
+
+									<v-select
+										v-if="collectionFilterMode === 'exclude'"
+										v-model="excludedCollections"
+										:items="availableCollections"
+										:disabled="lockInterface || isLoadingCollections"
+										:loading="isLoadingCollections"
+										:multiple-preview-threshold="2"
+										item-text="label"
+										item-value="value"
+										placeholder="Select collections to exclude..."
+										multiple
+										class="tab-select"
+									>
+										<template #prepend>
+											<v-icon name="remove_circle" />
+										</template>
+									</v-select>
+								</div>
+							</v-tab-item>
+
+							<!-- Content Tab -->
+							<v-tab-item value="content">
+								<div class="tab-panel">
+									<h4>Content Collection Filtering</h4>
+									<p class="tab-hint">Select which collections' content to migrate.</p>
+
+									<v-select
+										v-if="collectionFilterMode === 'include' && selectedCollections.length > 0"
+										v-model="contentCollections"
+										:items="availableCollections.filter(c => selectedCollections.includes(c.value))"
+										:disabled="lockInterface || isLoadingCollections"
+										:loading="isLoadingCollections"
+										:multiple-preview-threshold="2"
+										item-text="label"
+										item-value="value"
+										placeholder="All schema-selected collections (or select specific)"
+										multiple
+										class="tab-select"
+									>
+										<template #prepend>
+											<v-icon name="table_rows" />
+										</template>
+									</v-select>
+
+									<v-notice v-else-if="collectionFilterMode === 'all'" type="info" class="tab-notice">
+										All collections will have their content migrated. Use the Schema tab to filter collections first.
+									</v-notice>
+
+									<v-notice v-else-if="collectionFilterMode === 'exclude'" type="info" class="tab-notice">
+										Content from all non-excluded collections will be migrated.
+									</v-notice>
+
+									<v-notice v-else type="warning" class="tab-notice">
+										Please select collections in the Schema tab first.
+									</v-notice>
+
+									<div class="content-files-section">
+										<h4>Files & Folders</h4>
+										<p class="tab-hint">Configure file migration options.</p>
+										<div class="files-checkboxes">
+											<v-checkbox
+												v-model="scope.files"
+												label="Include files"
+												:disabled="lockInterface"
+											/>
+											<v-checkbox
+												v-model="scope.folders"
+												label="Include folder structure"
+												:disabled="lockInterface"
+											/>
+										</div>
+									</div>
+								</div>
+							</v-tab-item>
+
+							<!-- Users Tab -->
+							<v-tab-item value="users">
+								<div class="tab-panel">
+									<h4>Users Granular Options</h4>
+									<p class="tab-hint">Select which user-related data to migrate and optionally filter specific items.</p>
+
+									<!-- Roles Section -->
+									<div class="users-section">
+										<div class="section-header">
+											<v-checkbox
+												v-model="usersGranular.roles"
+												label="Roles"
+												:disabled="lockInterface"
+											/>
+											<span v-if="selectedRoles.length > 0" class="selection-badge">
+												{{ selectedRoles.length }} selected
+											</span>
+										</div>
+										<v-select
+											v-if="usersGranular.roles"
+											v-model="selectedRoles"
+											:items="availableRoles.map(r => ({ text: r.name, value: r.id }))"
+											:disabled="lockInterface"
+											multiple
+											placeholder="All roles (or select specific)"
+											class="section-select"
+										/>
+									</div>
+
+									<!-- Policies Section -->
+									<div class="users-section">
+										<div class="section-header">
+											<v-checkbox
+												v-model="usersGranular.policies"
+												label="Policies"
+												:disabled="lockInterface || !usersGranular.roles"
+											/>
+											<span v-if="selectedPolicies.length > 0" class="selection-badge">
+												{{ selectedPolicies.length }} selected
+											</span>
+										</div>
+										<v-select
+											v-if="usersGranular.policies"
+											v-model="selectedPolicies"
+											:items="availablePolicies.map(p => ({ text: p.name, value: p.id }))"
+											:disabled="lockInterface || !usersGranular.roles"
+											multiple
+											placeholder="All policies (or select specific)"
+											class="section-select"
+										/>
+									</div>
+
+									<!-- Permissions Section -->
+									<div class="users-section">
+										<div class="section-header">
+											<v-checkbox
+												v-model="usersGranular.permissions"
+												label="Permissions"
+												:disabled="lockInterface || !usersGranular.policies"
+											/>
+											<span v-if="selectedPermissions.length > 0" class="selection-badge">
+												{{ selectedPermissions.length }} selected
+											</span>
+										</div>
+										<v-select
+											v-if="usersGranular.permissions"
+											v-model="selectedPermissions"
+											:items="availablePermissions.map(p => ({ text: `${p.collection} - ${p.action}`, value: p.id }))"
+											:disabled="lockInterface || !usersGranular.policies"
+											multiple
+											placeholder="All permissions (or select specific)"
+											class="section-select"
+										/>
+									</div>
+
+									<!-- User Accounts Section -->
+									<div class="users-section">
+										<div class="section-header">
+											<v-checkbox
+												v-model="usersGranular.userAccounts"
+												label="User Accounts"
+												:disabled="lockInterface || !usersGranular.roles"
+											/>
+											<span v-if="selectedUserAccounts.length > 0" class="selection-badge">
+												{{ selectedUserAccounts.length }} selected
+											</span>
+										</div>
+										<v-select
+											v-if="usersGranular.userAccounts"
+											v-model="selectedUserAccounts"
+											:items="availableUsers.map(u => ({ text: u.email || `${u.first_name} ${u.last_name}`.trim() || u.id, value: u.id }))"
+											:disabled="lockInterface || !usersGranular.roles"
+											multiple
+											placeholder="All users (or select specific)"
+											class="section-select"
+										/>
+									</div>
+
+									<!-- Access Rules Section -->
+									<div class="users-section">
+										<div class="section-header">
+											<v-checkbox
+												v-model="usersGranular.access"
+												label="Access Rules"
+												:disabled="lockInterface || !usersGranular.userAccounts || !usersGranular.policies"
+											/>
+											<span v-if="selectedAccessRules.length > 0" class="selection-badge">
+												{{ selectedAccessRules.length }} selected
+											</span>
+										</div>
+										<v-select
+											v-if="usersGranular.access"
+											v-model="selectedAccessRules"
+											:items="availableAccessRules.map(a => ({ text: `${a.role || a.user || 'Public'} - ${a.policy}`, value: a.id }))"
+											:disabled="lockInterface || !usersGranular.userAccounts || !usersGranular.policies"
+											multiple
+											placeholder="All access rules (or select specific)"
+											class="section-select"
+										/>
+									</div>
+
+									<div class="dependency-hint">
+										<v-icon name="info" small />
+										<span>Dependencies: Policies require Roles, Permissions require Policies, User Accounts require Roles, Access requires Users + Policies. Selecting a user auto-selects their role.</span>
+									</div>
+								</div>
+							</v-tab-item>
+
+							<!-- Flows Tab -->
+							<v-tab-item value="flows">
+								<div class="tab-panel">
+									<h4>Flow Selection</h4>
+									<p class="tab-hint">Select specific flows to migrate, or leave empty for all.</p>
+
+									<v-select
+										v-model="selectedFlows"
+										:items="availableFlows.map(f => ({ text: f.name, value: f.id }))"
+										:disabled="lockInterface"
+										multiple
+										placeholder="All flows (or select specific)"
+										class="tab-select"
+									>
+										<template #prepend>
+											<v-icon name="bolt" />
+										</template>
+									</v-select>
+
+									<div v-if="selectedFlows.length > 0" class="selection-info">
+										<v-icon name="check_circle" small />
+										<span>{{ selectedFlows.length }} flow(s) selected. Related operations will be included automatically.</span>
+									</div>
+								</div>
+							</v-tab-item>
+
+							<!-- Extensions Tab -->
+							<v-tab-item value="extensions">
+								<div class="tab-panel">
+									<h4>Extension Selection</h4>
+									<p class="tab-hint">Select specific extensions to migrate, or leave empty for all registry extensions.</p>
+
+									<v-select
+										v-model="selectedExtensions"
+										:items="availableExtensions
+											.filter(e => e.source === 'registry')
+											.map(e => ({ text: e.name, value: e.name }))"
+										:disabled="lockInterface"
+										multiple
+										placeholder="All registry extensions (or select specific)"
+										class="tab-select"
+									>
+										<template #prepend>
+											<v-icon name="extension" />
+										</template>
+									</v-select>
+
+									<div v-if="selectedExtensions.length > 0" class="selection-info">
+										<v-icon name="check_circle" small />
+										<span>{{ selectedExtensions.length }} extension(s) selected.</span>
+									</div>
+
+									<div v-if="availableExtensions.some(e => e.source === 'local')" class="local-extensions-note">
+										<v-icon name="info" small />
+										<span>
+											{{ availableExtensions.filter(e => e.source === 'local').length }} local extension(s) found.
+											Local extensions cannot be auto-migrated and must be installed manually on the target.
+										</span>
+									</div>
+								</div>
+							</v-tab-item>
+						</v-tabs-items>
 					</div>
 				</div>
 
@@ -1061,52 +1606,221 @@ h3.skipped .icon i::after {
 	box-shadow: 0 0 0 1px var(--theme--primary-background);
 }
 
-/* Collection-level filtering styles */
-.migration-collection-filter {
+/* Tab-based UI styles */
+.migration-tabs-container {
 	margin-top: 20px;
-	padding: var(--theme--form--field--input--padding);
-	background-color: var(--theme--background-normal);
-	border-radius: var(--theme--border-radius);
 }
 
-.collection-filter-header {
-	display: flex;
+.migration-tabs {
+	border-bottom: 2px solid var(--theme--border-color);
+}
+
+.migration-tabs .v-tab {
+	display: inline-flex;
 	align-items: center;
-	gap: 8px;
-	margin-bottom: 12px;
+	gap: 6px;
+	padding: 10px 16px;
+	font-size: 14px;
+	font-weight: 500;
+	color: var(--theme--foreground-subdued);
+	background: transparent;
+	border: none;
+	border-bottom: 2px solid transparent;
+	margin-bottom: -2px;
+	cursor: pointer;
+	transition: all 0.2s ease;
 }
 
-.collection-filter-header span {
-	flex-grow: 1;
+.migration-tabs .v-tab:hover {
+	color: var(--theme--foreground);
+	background-color: var(--theme--background-normal);
+}
+
+.migration-tabs .v-tab.active {
+	color: var(--theme--primary);
+	border-bottom-color: var(--theme--primary);
+}
+
+.migration-tabs .v-tab .v-icon {
+	--v-icon-size: 18px;
+}
+
+.migration-tab-content {
+	margin-top: 0;
+}
+
+.tab-panel {
+	padding: 20px;
+	background-color: var(--theme--background-normal);
+	border: 1px solid var(--theme--border-color);
+	border-top: none;
+	border-radius: 0 0 var(--theme--border-radius) var(--theme--border-radius);
+}
+
+.tab-panel h4 {
+	margin: 0 0 8px 0;
 	font-weight: 600;
+	font-size: 14px;
+	color: var(--theme--foreground);
 }
 
-.collection-filter-header .v-select {
-	max-width: 180px;
+.tab-panel .tab-hint {
+	margin-bottom: 16px;
+	font-size: 12px;
+	color: var(--theme--foreground-subdued);
 }
 
-.collection-select {
-	margin-top: 8px;
-}
-
-.collection-select .v-select {
+.tab-panel .tab-select {
 	width: 100%;
+	margin-top: 12px;
 }
 
-.content-collection-select {
-	margin-top: 16px;
-	padding-top: 16px;
+.tab-panel .tab-notice {
+	margin-top: 12px;
+}
+
+.filter-mode-selector {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	margin-bottom: 8px;
+}
+
+.filter-mode-selector .v-radio {
+	margin: 0;
+}
+
+.content-files-section {
+	margin-top: 24px;
+	padding-top: 20px;
 	border-top: 1px solid var(--theme--border-color);
 }
 
-.content-collection-select .v-select {
-	width: 100%;
-	margin-top: 8px;
+.files-checkboxes {
+	display: flex;
+	gap: 24px;
+	margin-top: 12px;
 }
 
-.content-hint {
-	margin-top: 8px;
+.files-checkboxes .v-checkbox {
+	margin: 0;
+}
+
+.granular-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+	gap: 12px;
+	margin-bottom: 16px;
+}
+
+.granular-grid .v-checkbox {
+	margin: 0;
+}
+
+.dependency-hint {
+	display: flex;
+	align-items: flex-start;
+	gap: 8px;
+	padding: 12px;
+	background-color: var(--theme--background-subdued);
+	border-radius: var(--theme--border-radius);
 	font-size: 12px;
 	color: var(--theme--foreground-subdued);
+}
+
+.dependency-hint .v-icon {
+	flex-shrink: 0;
+	margin-top: 2px;
+}
+
+.selection-info {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-top: 12px;
+	padding: 10px 14px;
+	background-color: var(--theme--primary-background);
+	border-radius: var(--theme--border-radius);
+	font-size: 13px;
+	color: var(--theme--primary);
+}
+
+.selection-info .v-icon {
+	--v-icon-color: var(--theme--primary);
+}
+
+.local-extensions-note {
+	display: flex;
+	align-items: flex-start;
+	gap: 8px;
+	margin-top: 12px;
+	padding: 10px 14px;
+	background-color: var(--theme--warning-background);
+	border-radius: var(--theme--border-radius);
+	font-size: 13px;
+	color: var(--theme--warning);
+}
+
+.local-extensions-note .v-icon {
+	--v-icon-color: var(--theme--warning);
+	flex-shrink: 0;
+	margin-top: 2px;
+}
+
+@media (max-width: 600px) {
+	.migration-tabs .v-tab {
+		padding: 8px 12px;
+		font-size: 13px;
+	}
+
+	.migration-tabs .v-tab .v-icon {
+		display: none;
+	}
+
+	.granular-grid {
+		grid-template-columns: 1fr;
+	}
+
+	.files-checkboxes {
+		flex-direction: column;
+		gap: 12px;
+	}
+}
+
+/* Phase 6: Users tab specific item selection */
+.users-section {
+	margin-bottom: 16px;
+	padding-bottom: 16px;
+	border-bottom: 1px solid var(--theme--border-color-subdued);
+}
+
+.users-section:last-of-type {
+	border-bottom: none;
+	margin-bottom: 16px;
+}
+
+.section-header {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	margin-bottom: 8px;
+}
+
+.section-header .v-checkbox {
+	margin: 0;
+}
+
+.selection-badge {
+	font-size: 11px;
+	padding: 2px 8px;
+	background-color: var(--theme--primary-background);
+	color: var(--theme--primary);
+	border-radius: 12px;
+	font-weight: 500;
+}
+
+.section-select {
+	width: 100%;
+	margin-top: 8px;
 }
 </style>

--- a/packages/migration-bundle/src/migration-module/module.vue
+++ b/packages/migration-bundle/src/migration-module/module.vue
@@ -179,6 +179,19 @@ export default defineComponent({
 		const selectedUserAccounts = ref<string[]>([]);
 		const selectedAccessRules = ref<number[]>([]);
 
+		// Issue #013: Settings filtering
+		const settingsFilterMode = ref<'all' | 'selected'>('all');
+		const availableSettingsFields = ref<Array<{ text: string; value: string }>>([]);
+		const selectedSettingsFields = ref<string[]>([]);
+		const isLoadingSettings = ref<boolean>(false);
+
+		// Issue #013: Translations filtering
+		const translationsFilterMode = ref<'all' | 'filtered'>('all');
+		const availableLanguages = ref<Array<{ text: string; value: string }>>([]);
+		const selectedLanguages = ref<string[]>([]);
+		const translationKeyPattern = ref<string>('');
+		const isLoadingLanguages = ref<boolean>(false);
+
 		// Tab-based UI - active tab for granular options
 		const activeTab = ref<string[]>(['schema']);
 
@@ -190,7 +203,7 @@ export default defineComponent({
 			}
 			// Check if current tab is still valid
 			const currentTab = activeTab.value[0];
-			const tabOptions = ['schema', 'content', 'users', 'flows', 'extensions'];
+			const tabOptions = ['schema', 'content', 'users', 'flows', 'extensions', 'settings', 'translations'];
 			if (currentTab && selections.includes(currentTab as Options)) {
 				return; // Current tab is still valid
 			}
@@ -299,10 +312,87 @@ export default defineComponent({
 			]);
 		};
 
+		// Issue #013: Load available settings fields
+		const loadSettingsFields = async () => {
+			isLoadingSettings.value = true;
+			try {
+				const response = await api.get('/settings');
+				const settings = response.data.data || {};
+				// Extract field names from settings object
+				const fields = Object.keys(settings)
+					.filter(key => !key.startsWith('id')) // Exclude id field
+					.map(key => ({
+						text: key.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase()),
+						value: key,
+					}))
+					.sort((a, b) => a.text.localeCompare(b.text));
+				availableSettingsFields.value = fields;
+			}
+			catch (error) {
+				console.error('Failed to load settings fields:', error);
+			}
+			finally {
+				isLoadingSettings.value = false;
+			}
+		};
+
+		// Issue #013: Load available languages for translations
+		const loadLanguages = async () => {
+			isLoadingLanguages.value = true;
+			try {
+				const response = await api.get('/translations', {
+					params: {
+						fields: ['language'],
+						groupBy: ['language'],
+						limit: -1,
+					},
+				});
+				const translations = response.data.data || [];
+				const languages = [...new Set(translations.map((t: any) => t.language))]
+					.filter(Boolean)
+					.map(lang => ({
+						text: lang as string,
+						value: lang as string,
+					}))
+					.sort((a, b) => a.text.localeCompare(b.text));
+				availableLanguages.value = languages;
+			}
+			catch (error) {
+				console.error('Failed to load languages:', error);
+				// Fallback: try to get unique languages from all translations
+				try {
+					const fallbackResponse = await api.get('/translations', { params: { fields: ['language'], limit: -1 } });
+					const allTranslations = fallbackResponse.data.data || [];
+					const uniqueLanguages = [...new Set(allTranslations.map((t: any) => t.language))]
+						.filter(Boolean)
+						.map(lang => ({
+							text: lang as string,
+							value: lang as string,
+						}))
+						.sort((a, b) => a.text.localeCompare(b.text));
+					availableLanguages.value = uniqueLanguages;
+				}
+				catch (fallbackError) {
+					console.error('Failed to load languages (fallback):', fallbackError);
+				}
+			}
+			finally {
+				isLoadingLanguages.value = false;
+			}
+		};
+
 		// Load Users tab data when tab becomes active
 		watch(activeTab, (tab) => {
 			if (tab[0] === 'users' && availableRoles.value.length === 0) {
 				loadUsersTabData();
+			}
+			// Issue #013: Load settings fields when Settings tab becomes active
+			if (tab[0] === 'settings' && availableSettingsFields.value.length === 0) {
+				loadSettingsFields();
+			}
+			// Issue #013: Load languages when Translations tab becomes active
+			if (tab[0] === 'translations' && availableLanguages.value.length === 0) {
+				loadLanguages();
 			}
 		});
 
@@ -667,6 +757,21 @@ export default defineComponent({
 				extendedScope.selectedExtensions = selectedExtensions.value;
 			}
 
+			// Issue #013: Add settings filtering to scope
+			if (scope.settings && settingsFilterMode.value === 'selected') {
+				extendedScope.selectedSettings = selectedSettingsFields.value;
+			}
+
+			// Issue #013: Add translations filtering to scope
+			if (scope.translations && translationsFilterMode.value === 'filtered') {
+				if (selectedLanguages.value.length > 0) {
+					extendedScope.selectedLanguages = selectedLanguages.value;
+				}
+				if (translationKeyPattern.value.trim()) {
+					extendedScope.translationKeyPattern = translationKeyPattern.value.trim();
+				}
+			}
+
 			// Files defaults to true if content is selected (backward compatibility)
 			if (scope.content && !migrationOptionsSelections.value?.includes('files')) {
 				extendedScope.files = true;
@@ -755,6 +860,17 @@ export default defineComponent({
 			selectedPermissions,
 			selectedUserAccounts,
 			selectedAccessRules,
+			// Issue #013: Settings filtering
+			settingsFilterMode,
+			availableSettingsFields,
+			selectedSettingsFields,
+			isLoadingSettings,
+			// Issue #013: Translations filtering
+			translationsFilterMode,
+			availableLanguages,
+			selectedLanguages,
+			translationKeyPattern,
+			isLoadingLanguages,
 		};
 	},
 });
@@ -929,6 +1045,20 @@ export default defineComponent({
 							>
 								<v-icon name="extension" small />
 								Extensions
+							</v-tab>
+							<v-tab
+								v-if="migrationOptionsSelections?.includes('settings')"
+								value="settings"
+							>
+								<v-icon name="settings" small />
+								Settings
+							</v-tab>
+							<v-tab
+								v-if="migrationOptionsSelections?.includes('translations')"
+								value="translations"
+							>
+								<v-icon name="translate" small />
+								Translations
 							</v-tab>
 						</v-tabs>
 
@@ -1239,6 +1369,137 @@ export default defineComponent({
 											{{ availableExtensions.filter(e => e.source === 'local').length }} local extension(s) found.
 											Local extensions cannot be auto-migrated and must be installed manually on the target.
 										</span>
+									</div>
+								</div>
+							</v-tab-item>
+
+							<!-- Settings Tab (Issue #013) -->
+							<v-tab-item value="settings">
+								<div class="tab-panel">
+									<h4>Settings Filtering</h4>
+									<p class="tab-hint">Choose which settings to migrate from the source instance.</p>
+
+									<div class="filter-mode-selector">
+										<v-radio
+											v-model="settingsFilterMode"
+											value="all"
+											label="Migrate all settings"
+											:disabled="lockInterface"
+										/>
+										<v-radio
+											v-model="settingsFilterMode"
+											value="selected"
+											label="Select specific settings"
+											:disabled="lockInterface"
+										/>
+									</div>
+
+									<v-select
+										v-if="settingsFilterMode === 'selected'"
+										v-model="selectedSettingsFields"
+										:items="availableSettingsFields"
+										:disabled="lockInterface || isLoadingSettings"
+										:loading="isLoadingSettings"
+										:multiple-preview-threshold="3"
+										item-text="text"
+										item-value="value"
+										placeholder="Select settings fields to migrate..."
+										multiple
+										class="tab-select"
+									>
+										<template #prepend>
+											<v-icon name="tune" />
+										</template>
+									</v-select>
+
+									<div v-if="settingsFilterMode === 'selected' && selectedSettingsFields.length > 0" class="selection-info">
+										<v-icon name="check_circle" small />
+										<span>{{ selectedSettingsFields.length }} setting(s) selected for migration.</span>
+									</div>
+
+									<v-notice v-if="settingsFilterMode === 'selected' && selectedSettingsFields.length === 0 && !isLoadingSettings" type="warning" class="tab-notice">
+										<v-icon name="warning" small />
+										No settings selected. Settings migration will be skipped.
+									</v-notice>
+
+									<div class="settings-merge-note">
+										<v-icon name="info" small />
+										<span>Settings are merged with the target instance. Source values will override target values for selected fields.</span>
+									</div>
+								</div>
+							</v-tab-item>
+
+							<!-- Translations Tab (Issue #013) -->
+							<v-tab-item value="translations">
+								<div class="tab-panel">
+									<h4>Translations Filtering</h4>
+									<p class="tab-hint">Filter translations by language or key pattern.</p>
+
+									<div class="filter-mode-selector">
+										<v-radio
+											v-model="translationsFilterMode"
+											value="all"
+											label="Migrate all translations"
+											:disabled="lockInterface"
+										/>
+										<v-radio
+											v-model="translationsFilterMode"
+											value="filtered"
+											label="Filter translations"
+											:disabled="lockInterface"
+										/>
+									</div>
+
+									<div v-if="translationsFilterMode === 'filtered'" class="translations-filters">
+										<div class="filter-section">
+											<h5>Language Selection</h5>
+											<v-select
+												v-model="selectedLanguages"
+												:items="availableLanguages"
+												:disabled="lockInterface || isLoadingLanguages"
+												:loading="isLoadingLanguages"
+												:multiple-preview-threshold="3"
+												item-text="text"
+												item-value="value"
+												placeholder="All languages (or select specific)"
+												multiple
+												class="tab-select"
+											>
+												<template #prepend>
+													<v-icon name="language" />
+												</template>
+											</v-select>
+										</div>
+
+										<div class="filter-section">
+											<h5>Key Pattern Filter (RegEx)</h5>
+											<v-input
+												v-model="translationKeyPattern"
+												:disabled="lockInterface"
+												placeholder="e.g., ^admin\\. or menu_.*"
+												class="tab-input"
+											>
+												<template #prepend>
+													<v-icon name="search" />
+												</template>
+											</v-input>
+											<p class="filter-hint">Use regular expressions to filter translation keys. Leave empty for all keys.</p>
+										</div>
+									</div>
+
+									<div v-if="translationsFilterMode === 'filtered' && selectedLanguages.length > 0" class="selection-info">
+										<v-icon name="check_circle" small />
+										<span>{{ selectedLanguages.length }} language(s) selected.</span>
+									</div>
+
+									<v-notice v-if="translationsFilterMode === 'filtered' && selectedLanguages.length === 0 && !isLoadingLanguages" type="warning" class="tab-notice">
+										<v-icon name="warning" small />
+										No languages selected. Translations migration will be skipped.
+									</v-notice>
+
+									<div class="translations-merge-note">
+										<v-icon name="info" small />
+										<span>Translations are merged by key. Existing translations on the target will be updated if keys match.</span>
 									</div>
 								</div>
 							</v-tab-item>
@@ -1822,5 +2083,54 @@ h3.skipped .icon i::after {
 .section-select {
 	width: 100%;
 	margin-top: 8px;
+}
+
+/* Issue #013: Settings and Translations tab styles */
+.settings-merge-note,
+.translations-merge-note {
+	display: flex;
+	align-items: flex-start;
+	gap: 8px;
+	margin-top: 16px;
+	padding: 12px;
+	background-color: var(--theme--background-subdued);
+	border-radius: var(--theme--border-radius);
+	font-size: 12px;
+	color: var(--theme--foreground-subdued);
+}
+
+.settings-merge-note .v-icon,
+.translations-merge-note .v-icon {
+	flex-shrink: 0;
+	margin-top: 2px;
+}
+
+.translations-filters {
+	margin-top: 16px;
+}
+
+.filter-section {
+	margin-bottom: 20px;
+}
+
+.filter-section:last-child {
+	margin-bottom: 0;
+}
+
+.filter-section h5 {
+	margin: 0 0 8px 0;
+	font-weight: 500;
+	font-size: 13px;
+	color: var(--theme--foreground);
+}
+
+.filter-hint {
+	margin-top: 6px;
+	font-size: 11px;
+	color: var(--theme--foreground-subdued);
+}
+
+.tab-input {
+	width: 100%;
 }
 </style>

--- a/packages/migration-bundle/src/migration-module/module.vue
+++ b/packages/migration-bundle/src/migration-module/module.vue
@@ -2,11 +2,11 @@
 import type { AxiosProgressEvent } from 'axios';
 import type { Payload } from '../types/extension';
 import { useApi } from '@directus/extensions-sdk';
-import { defineComponent, reactive, ref, watch } from 'vue';
+import { computed, defineComponent, reactive, ref, watch } from 'vue';
 import { md } from '../utils/md';
 import SupportNavigation from './components/navigation.vue';
 
-type Options = 'content' | 'users' | 'comments' | 'presets' | 'dashboards' | 'extensions' | 'flows' | 'force';
+type Options = 'schema' | 'content' | 'users' | 'comments' | 'presets' | 'dashboards' | 'extensions' | 'flows' | 'force';
 
 export default defineComponent({
 	components: {
@@ -39,10 +39,21 @@ export default defineComponent({
 			options: [],
 		});
 
+		// Collection-level filtering
+		const availableCollections = ref<{ label: string; value: string }[]>([]);
+		const selectedCollections = ref<string[]>([]);
+		const excludedCollections = ref<string[]>([]);
+		const collectionFilterMode = ref<'all' | 'include' | 'exclude'>('all');
+		const isLoadingCollections = ref<boolean>(false);
+
 		const migrationOptions = ref<{
 			label: string;
 			value: string;
 		}[]>([
+			{
+				label: 'Schema',
+				value: 'schema',
+			},
 			{
 				label: 'Content',
 				value: 'content',
@@ -75,7 +86,8 @@ export default defineComponent({
 
 		const migrationOptionsSelections = ref<Options[] | null>(migrationOptions.value.map((o) => o.value as Options));
 
-		const scope = reactive<Record<Options, boolean>>({
+		const scope = reactive<Record<Options, boolean> & { selectedCollections?: string[]; excludedCollections?: string[]; contentCollections?: string[] }>({
+			schema: true,
 			users: false,
 			content: false,
 			comments: false,
@@ -86,7 +98,55 @@ export default defineComponent({
 			force: false,
 		});
 
+		// Content-specific collection selection (subset of schema-selected collections)
+		const contentCollections = ref<string[]>([]);
+
+		// Fix 6.1: Show Force checkbox when partial migration is selected
+		const allMigrationOptions = ['schema', 'content', 'users', 'comments', 'presets', 'dashboards', 'extensions', 'flows'];
+		const showForceCheckbox = computed(() => {
+			// Show if compatibility check suggests force
+			const forceInMessage = validationMessage.value?.message?.includes('force') || false;
+
+			// Show if partial migration (not all options selected)
+			const partialMigration = !migrationOptionsSelections.value ||
+				migrationOptionsSelections.value.length < allMigrationOptions.length;
+
+			return forceInMessage || partialMigration;
+		});
+
 		const api = useApi();
+
+		// Fix 3.3: Sync contentCollections with selectedCollections
+		// When user selects collections for schema, auto-select them for content too
+		watch(selectedCollections, (newValue) => {
+			if (newValue && newValue.length > 0) {
+				// Auto-sync: content collections = schema selected collections
+				contentCollections.value = [...newValue];
+			}
+		}, { immediate: true });
+
+		// Load available collections from Directus
+		const loadCollections = async () => {
+			isLoadingCollections.value = true;
+			try {
+				const response = await api.get('/collections');
+				const collections = response.data.data || [];
+				availableCollections.value = collections
+					.filter((c: any) => !c.collection.startsWith('directus_'))
+					.filter((c: any) => c.schema !== null)
+					.map((c: any) => ({
+						label: c.meta?.translations?.[0]?.translation || c.collection,
+						value: c.collection,
+					}))
+					.sort((a: any, b: any) => a.label.localeCompare(b.label));
+			}
+			catch (error) {
+				console.error('Failed to load collections:', error);
+			}
+			finally {
+				isLoadingCollections.value = false;
+			}
+		};
 
 		// Load ENV defaults
 		const loadEnvDefaults = async () => {
@@ -98,9 +158,24 @@ export default defineComponent({
 				if (defaults.token) token.value = defaults.token;
 
 				if (defaults.options && defaults.options.length > 0) {
-					migrationOptionsSelections.value = defaults.options.filter((opt: string) =>
+					let options = defaults.options.filter((opt: string) =>
 						migrationOptions.value.some((o) => o.value === opt),
 					) as Options[];
+					// Fix 3.2: Ensure 'schema' is always included in options
+					if (!options.includes('schema')) {
+						options = ['schema', ...options];
+					}
+					migrationOptionsSelections.value = options;
+				}
+
+				// Load collection-level filtering from ENV
+				if (defaults.selectedCollections && defaults.selectedCollections.length > 0) {
+					selectedCollections.value = defaults.selectedCollections;
+					collectionFilterMode.value = 'include';
+				}
+				else if (defaults.excludedCollections && defaults.excludedCollections.length > 0) {
+					excludedCollections.value = defaults.excludedCollections;
+					collectionFilterMode.value = 'exclude';
 				}
 			}
 			catch {
@@ -136,7 +211,12 @@ export default defineComponent({
 					: preset.layout_options;
 				baseURL.value = options.baseURL || '';
 				token.value = options.token || '';
-				migrationOptionsSelections.value = options.selectedOptions || [];
+				// Fix 3.2: Ensure 'schema' is always included in preset options
+				let selectedOptions = options.selectedOptions || [];
+				if (!selectedOptions.includes('schema')) {
+					selectedOptions = ['schema', ...selectedOptions];
+				}
+				migrationOptionsSelections.value = selectedOptions;
 
 				// Store original config
 				originalConfig.value = {
@@ -211,6 +291,9 @@ export default defineComponent({
 		// Initialize on mount
 		const initialize = async () => {
 			isLoadingConfig.value = true;
+
+			// Load available collections for filtering
+			await loadCollections();
 
 			// Load presets first
 			await loadPresets();
@@ -318,6 +401,28 @@ export default defineComponent({
 
 			scope.force = forceSchema.value;
 
+			// Add collection-level filtering to scope
+			if (collectionFilterMode.value === 'include' && selectedCollections.value.length > 0) {
+				scope.selectedCollections = selectedCollections.value;
+				delete scope.excludedCollections;
+			}
+			else if (collectionFilterMode.value === 'exclude' && excludedCollections.value.length > 0) {
+				scope.excludedCollections = excludedCollections.value;
+				delete scope.selectedCollections;
+			}
+			else {
+				delete scope.selectedCollections;
+				delete scope.excludedCollections;
+			}
+
+			// Add content-specific collection selection
+			if (contentCollections.value.length > 0) {
+				scope.contentCollections = contentCollections.value;
+			}
+			else {
+				delete scope.contentCollections;
+			}
+
 			response.value = await api.post(`/migration/${dryRun ? 'dry-run' : 'run'}`, { baseURL, token, scope }, {
 				onDownloadProgress: (progressEvent: AxiosProgressEvent) => {
 					let eventObj: XMLHttpRequest | undefined;
@@ -373,6 +478,15 @@ export default defineComponent({
 			confirmDelete,
 			hasChanges,
 			updatePreset,
+			// Collection-level filtering
+			availableCollections,
+			selectedCollections,
+			excludedCollections,
+			collectionFilterMode,
+			isLoadingCollections,
+			contentCollections,
+			// Fix 6.1: Force checkbox visibility
+			showForceCheckbox,
 		};
 	},
 });
@@ -462,14 +576,20 @@ export default defineComponent({
 						<v-notice :icon="validationMessage.icon" :type="validationMessage.status">
 							{{ validationMessage.message }}
 						</v-notice>
+					</div>
+
+					<!-- Fix 6.1: Force checkbox - visible for partial migrations -->
+					<div v-if="showForceCheckbox && validationMessage" class="migration-force-option">
 						<v-checkbox
-							v-if="validationMessage.message.includes('force')"
 							v-model="forceSchema"
 							label="Force"
 							:disabled="lockInterface"
 						>
 							Force
 						</v-checkbox>
+						<p v-if="!validationMessage.message.includes('force')" class="force-hint">
+							Enable Force mode for partial migrations to apply correctly.
+						</p>
 					</div>
 
 					<div v-if="forceSchema || (validationMessage && validationMessage.status === 'success')" class="migration-start">
@@ -502,6 +622,82 @@ export default defineComponent({
 						<v-button :disabled="lockInterface" @click="extractSchema({ baseURL, token, dryRun })">
 							Start
 						</v-button>
+					</div>
+
+					<!-- Collection-level filtering (shown when Schema OR Content is selected) -->
+					<div v-if="(forceSchema || (validationMessage && validationMessage.status === 'success')) && (migrationOptionsSelections?.includes('schema') || migrationOptionsSelections?.includes('content'))" class="migration-collection-filter">
+						<div class="collection-filter-header">
+							<v-icon name="filter_list" />
+							<span>Schema Collection Filter</span>
+							<v-select
+								v-model="collectionFilterMode"
+								:items="[
+									{ text: 'All Collections', value: 'all' },
+									{ text: 'Include Only', value: 'include' },
+									{ text: 'Exclude', value: 'exclude' },
+								]"
+								:disabled="lockInterface || isLoadingCollections"
+								placeholder="Filter Mode"
+							/>
+						</div>
+						<div v-if="collectionFilterMode === 'include'" class="collection-select">
+							<v-select
+								v-model="selectedCollections"
+								:items="availableCollections"
+								:disabled="lockInterface || isLoadingCollections"
+								:loading="isLoadingCollections"
+								:multiple-preview-threshold="2"
+								item-text="label"
+								item-value="value"
+								placeholder="Select collections for schema migration..."
+								multiple
+							>
+								<template #prepend>
+									<v-icon name="add_circle" />
+								</template>
+							</v-select>
+						</div>
+						<div v-if="collectionFilterMode === 'exclude'" class="collection-select">
+							<v-select
+								v-model="excludedCollections"
+								:items="availableCollections"
+								:disabled="lockInterface || isLoadingCollections"
+								:loading="isLoadingCollections"
+								:multiple-preview-threshold="2"
+								item-text="label"
+								item-value="value"
+								placeholder="Select collections to exclude..."
+								multiple
+							>
+								<template #prepend>
+									<v-icon name="remove_circle" />
+								</template>
+							</v-select>
+						</div>
+
+						<!-- Content collection selection (only when Content is selected AND collections are filtered) -->
+						<div v-if="migrationOptionsSelections?.includes('content') && collectionFilterMode === 'include' && selectedCollections.length > 0" class="content-collection-select">
+							<div class="collection-filter-header">
+								<v-icon name="storage" />
+								<span>Content Data Selection</span>
+							</div>
+							<v-select
+								v-model="contentCollections"
+								:items="availableCollections.filter(c => selectedCollections.includes(c.value))"
+								:disabled="lockInterface || isLoadingCollections"
+								:loading="isLoadingCollections"
+								:multiple-preview-threshold="2"
+								item-text="label"
+								item-value="value"
+								placeholder="Select which collections should have data migrated..."
+								multiple
+							>
+								<template #prepend>
+									<v-icon name="table_rows" />
+								</template>
+							</v-select>
+							<p class="content-hint">Only data from selected collections will be migrated. Leave empty to migrate all schema-selected collections' data.</p>
+						</div>
 					</div>
 				</div>
 
@@ -863,5 +1059,54 @@ h3.skipped .icon i::after {
 .migration-preset-selector.has-changes .preset-row {
 	border-color: var(--theme--primary);
 	box-shadow: 0 0 0 1px var(--theme--primary-background);
+}
+
+/* Collection-level filtering styles */
+.migration-collection-filter {
+	margin-top: 20px;
+	padding: var(--theme--form--field--input--padding);
+	background-color: var(--theme--background-normal);
+	border-radius: var(--theme--border-radius);
+}
+
+.collection-filter-header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-bottom: 12px;
+}
+
+.collection-filter-header span {
+	flex-grow: 1;
+	font-weight: 600;
+}
+
+.collection-filter-header .v-select {
+	max-width: 180px;
+}
+
+.collection-select {
+	margin-top: 8px;
+}
+
+.collection-select .v-select {
+	width: 100%;
+}
+
+.content-collection-select {
+	margin-top: 16px;
+	padding-top: 16px;
+	border-top: 1px solid var(--theme--border-color);
+}
+
+.content-collection-select .v-select {
+	width: 100%;
+	margin-top: 8px;
+}
+
+.content-hint {
+	margin-top: 8px;
+	font-size: 12px;
+	color: var(--theme--foreground-subdued);
 }
 </style>

--- a/packages/migration-bundle/src/migration-module/module.vue
+++ b/packages/migration-bundle/src/migration-module/module.vue
@@ -274,6 +274,57 @@ export default defineComponent({
 			{ deep: true },
 		);
 
+		// Issue #019 Fix: Defensive watchers to convert null to empty arrays
+		// Directus v-select returns null instead of [] when all items are deselected
+		watch(selectedExtensions, (val) => {
+			if (val === null) selectedExtensions.value = [];
+		});
+		watch(selectedFlows, (val) => {
+			if (val === null) selectedFlows.value = [];
+		});
+		watch(selectedBookmarks, (val) => {
+			if (val === null) selectedBookmarks.value = [];
+		});
+		watch(selectedInsights, (val) => {
+			if (val === null) selectedInsights.value = [];
+		});
+		watch(selectedRoles, (val) => {
+			if (val === null) selectedRoles.value = [];
+		});
+		watch(selectedPolicies, (val) => {
+			if (val === null) selectedPolicies.value = [];
+		});
+		watch(selectedPermissions, (val) => {
+			if (val === null) selectedPermissions.value = [];
+		});
+		watch(selectedUserAccounts, (val) => {
+			if (val === null) selectedUserAccounts.value = [];
+		});
+		watch(selectedAccessRules, (val) => {
+			if (val === null) selectedAccessRules.value = [];
+		});
+		watch(selectedCollections, (val) => {
+			if (val === null) selectedCollections.value = [];
+		});
+		watch(excludedCollections, (val) => {
+			if (val === null) excludedCollections.value = [];
+		});
+		watch(contentCollections, (val) => {
+			if (val === null) contentCollections.value = [];
+		});
+		watch(selectedFolders, (val) => {
+			if (val === null) selectedFolders.value = [];
+		});
+		watch(selectedSettingsFields, (val) => {
+			if (val === null) selectedSettingsFields.value = [];
+		});
+		watch(selectedLanguages, (val) => {
+			if (val === null) selectedLanguages.value = [];
+		});
+		watch(migrationOptionsSelections, (val) => {
+			if (val === null) migrationOptionsSelections.value = [];
+		});
+
 		// Load available collections from Directus
 		const loadCollections = async () => {
 			isLoadingCollections.value = true;
@@ -305,7 +356,7 @@ export default defineComponent({
 			// Include mode: null collection does NOT match any selected collection
 			if (collectionFilterMode.value === 'include') {
 				if (!collection) return false; // null != selected collections
-				if (selectedCollections.value.length === 0) return true;
+				if (!selectedCollections.value || selectedCollections.value.length === 0) return true;
 				return selectedCollections.value.includes(collection);
 			}
 
@@ -607,7 +658,7 @@ export default defineComponent({
 		// Phase 6: Auto-select dependencies when items are selected
 		// When user account is selected, auto-select their role
 		watch(selectedUserAccounts, (userIds) => {
-			if (userIds.length === 0) return;
+			if (!userIds || userIds.length === 0) return;
 			const users = availableUsers.value.filter(u => userIds.includes(u.id));
 			const roleIds = [...new Set(users.map(u => u.role).filter(Boolean))] as string[];
 			roleIds.forEach(roleId => {
@@ -619,7 +670,7 @@ export default defineComponent({
 
 		// When access rule is selected, auto-select role and policy
 		watch(selectedAccessRules, (accessIds) => {
-			if (accessIds.length === 0) return;
+			if (!accessIds || accessIds.length === 0) return;
 			const accessItems = availableAccessRules.value.filter(a => accessIds.includes(a.id));
 			accessItems.forEach(access => {
 				if (access.role && !selectedRoles.value.includes(access.role)) {
@@ -941,15 +992,15 @@ export default defineComponent({
 			const extendedScope: Record<string, any> = { ...scope };
 
 			// Add collection-level filtering to scope
-			if (collectionFilterMode.value === 'include' && selectedCollections.value.length > 0) {
+			if (collectionFilterMode.value === 'include' && selectedCollections.value && selectedCollections.value.length > 0) {
 				extendedScope.selectedCollections = selectedCollections.value;
 			}
-			else if (collectionFilterMode.value === 'exclude' && excludedCollections.value.length > 0) {
+			else if (collectionFilterMode.value === 'exclude' && excludedCollections.value && excludedCollections.value.length > 0) {
 				extendedScope.excludedCollections = excludedCollections.value;
 			}
 
 			// Add content-specific collection selection
-			if (contentCollections.value.length > 0) {
+			if (contentCollections.value && contentCollections.value.length > 0) {
 				extendedScope.contentCollections = contentCollections.value;
 			}
 
@@ -959,19 +1010,19 @@ export default defineComponent({
 
 				// Phase 6: Add users selection options
 				const usersSelection: Record<string, any> = {};
-				if (selectedRoles.value.length > 0) {
+				if (selectedRoles.value && selectedRoles.value.length > 0) {
 					usersSelection.selectedRoles = selectedRoles.value;
 				}
-				if (selectedPolicies.value.length > 0) {
+				if (selectedPolicies.value && selectedPolicies.value.length > 0) {
 					usersSelection.selectedPolicies = selectedPolicies.value;
 				}
-				if (selectedPermissions.value.length > 0) {
+				if (selectedPermissions.value && selectedPermissions.value.length > 0) {
 					usersSelection.selectedPermissions = selectedPermissions.value;
 				}
-				if (selectedUserAccounts.value.length > 0) {
+				if (selectedUserAccounts.value && selectedUserAccounts.value.length > 0) {
 					usersSelection.selectedUsers = selectedUserAccounts.value;
 				}
-				if (selectedAccessRules.value.length > 0) {
+				if (selectedAccessRules.value && selectedAccessRules.value.length > 0) {
 					usersSelection.selectedAccess = selectedAccessRules.value;
 				}
 				if (Object.keys(usersSelection).length > 0) {
@@ -980,12 +1031,12 @@ export default defineComponent({
 			}
 
 			// Add selected flows if flows is selected and specific flows are chosen
-			if (scope.flows && selectedFlows.value.length > 0) {
+			if (scope.flows && selectedFlows.value && selectedFlows.value.length > 0) {
 				extendedScope.selectedFlows = selectedFlows.value;
 			}
 
 			// Add selected extensions if extensions is selected and specific ones are chosen
-			if (scope.extensions && selectedExtensions.value.length > 0) {
+			if (scope.extensions && selectedExtensions.value && selectedExtensions.value.length > 0) {
 				extendedScope.selectedExtensions = selectedExtensions.value;
 			}
 
@@ -996,7 +1047,7 @@ export default defineComponent({
 
 			// Issue #013: Add translations filtering to scope
 			if (scope.translations && translationsFilterMode.value === 'filtered') {
-				if (selectedLanguages.value.length > 0) {
+				if (selectedLanguages.value && selectedLanguages.value.length > 0) {
 					extendedScope.selectedLanguages = selectedLanguages.value;
 				}
 				if (translationKeyPattern.value.trim()) {
@@ -1429,7 +1480,7 @@ export default defineComponent({
 									<p class="tab-hint">Select which collections' content to migrate.</p>
 
 									<v-select
-										v-if="collectionFilterMode === 'include' && selectedCollections.length > 0"
+										v-if="collectionFilterMode === 'include' && selectedCollections && selectedCollections.length > 0"
 										v-model="contentCollections"
 										:items="availableCollections.filter(c => selectedCollections.includes(c.value))"
 										:disabled="lockInterface || isLoadingCollections"
@@ -1514,7 +1565,7 @@ export default defineComponent({
 										</template>
 									</v-select>
 
-									<v-notice v-if="filesFilterMode === 'selected' && selectedFolders.length === 0" type="warning" class="tab-notice">
+									<v-notice v-if="filesFilterMode === 'selected' && (!selectedFolders || selectedFolders.length === 0)" type="warning" class="tab-notice">
 										No folders selected. Files migration will be skipped.
 									</v-notice>
 
@@ -1546,7 +1597,7 @@ export default defineComponent({
 												label="Roles"
 												:disabled="lockInterface"
 											/>
-											<span v-if="selectedRoles.length > 0" class="selection-badge">
+											<span v-if="selectedRoles && selectedRoles.length > 0" class="selection-badge">
 												{{ selectedRoles.length }} selected
 											</span>
 										</div>
@@ -1569,7 +1620,7 @@ export default defineComponent({
 												label="Policies"
 												:disabled="lockInterface || !usersGranular.roles"
 											/>
-											<span v-if="selectedPolicies.length > 0" class="selection-badge">
+											<span v-if="selectedPolicies && selectedPolicies.length > 0" class="selection-badge">
 												{{ selectedPolicies.length }} selected
 											</span>
 										</div>
@@ -1592,7 +1643,7 @@ export default defineComponent({
 												label="Permissions"
 												:disabled="lockInterface || !usersGranular.policies"
 											/>
-											<span v-if="selectedPermissions.length > 0" class="selection-badge">
+											<span v-if="selectedPermissions && selectedPermissions.length > 0" class="selection-badge">
 												{{ selectedPermissions.length }} selected
 											</span>
 										</div>
@@ -1615,7 +1666,7 @@ export default defineComponent({
 												label="User Accounts"
 												:disabled="lockInterface || !usersGranular.roles"
 											/>
-											<span v-if="selectedUserAccounts.length > 0" class="selection-badge">
+											<span v-if="selectedUserAccounts && selectedUserAccounts.length > 0" class="selection-badge">
 												{{ selectedUserAccounts.length }} selected
 											</span>
 										</div>
@@ -1638,7 +1689,7 @@ export default defineComponent({
 												label="Access Rules"
 												:disabled="lockInterface || !usersGranular.userAccounts || !usersGranular.policies"
 											/>
-											<span v-if="selectedAccessRules.length > 0" class="selection-badge">
+											<span v-if="selectedAccessRules && selectedAccessRules.length > 0" class="selection-badge">
 												{{ selectedAccessRules.length }} selected
 											</span>
 										</div>
@@ -1709,12 +1760,12 @@ export default defineComponent({
 										</template>
 									</v-select>
 
-									<div v-if="bookmarksFilterMode === 'selected' && selectedBookmarks.length > 0" class="selection-info">
+									<div v-if="bookmarksFilterMode === 'selected' && selectedBookmarks && selectedBookmarks.length > 0" class="selection-info">
 										<v-icon name="check_circle" small />
 										<span>{{ selectedBookmarks.length }} bookmark(s) selected for migration.</span>
 									</div>
 
-									<v-notice v-if="bookmarksFilterMode === 'selected' && selectedBookmarks.length === 0 && !isLoadingBookmarks" type="warning" class="tab-notice">
+									<v-notice v-if="bookmarksFilterMode === 'selected' && (!selectedBookmarks || selectedBookmarks.length === 0) && !isLoadingBookmarks" type="warning" class="tab-notice">
 										<v-icon name="warning" small />
 										No bookmarks selected. Bookmarks migration will be skipped.
 									</v-notice>
@@ -1765,7 +1816,7 @@ export default defineComponent({
 										</template>
 									</v-select>
 
-									<div v-if="insightsFilterMode === 'selected' && selectedInsights.length > 0" class="selection-info">
+									<div v-if="insightsFilterMode === 'selected' && selectedInsights && selectedInsights.length > 0" class="selection-info">
 										<v-icon name="check_circle" small />
 										<span>
 											{{ selectedInsights.length }} dashboard(s) selected
@@ -1773,7 +1824,7 @@ export default defineComponent({
 										</span>
 									</div>
 
-									<v-notice v-if="insightsFilterMode === 'selected' && selectedInsights.length === 0 && !isLoadingInsights" type="warning" class="tab-notice">
+									<v-notice v-if="insightsFilterMode === 'selected' && (!selectedInsights || selectedInsights.length === 0) && !isLoadingInsights" type="warning" class="tab-notice">
 										<v-icon name="warning" small />
 										No dashboards selected. Insights migration will be skipped.
 									</v-notice>
@@ -1814,7 +1865,7 @@ export default defineComponent({
 										</template>
 									</v-select>
 
-									<div v-if="selectedFlows.length > 0" class="selection-info">
+									<div v-if="selectedFlows && selectedFlows.length > 0" class="selection-info">
 										<v-icon name="check_circle" small />
 										<span>{{ selectedFlows.length }} flow(s) selected. Related operations will be included automatically.</span>
 									</div>
@@ -1842,7 +1893,7 @@ export default defineComponent({
 										</template>
 									</v-select>
 
-									<div v-if="selectedExtensions.length > 0" class="selection-info">
+									<div v-if="selectedExtensions && selectedExtensions.length > 0" class="selection-info">
 										<v-icon name="check_circle" small />
 										<span>{{ selectedExtensions.length }} extension(s) selected.</span>
 									</div>
@@ -1896,12 +1947,12 @@ export default defineComponent({
 										</template>
 									</v-select>
 
-									<div v-if="settingsFilterMode === 'selected' && selectedSettingsFields.length > 0" class="selection-info">
+									<div v-if="settingsFilterMode === 'selected' && selectedSettingsFields && selectedSettingsFields.length > 0" class="selection-info">
 										<v-icon name="check_circle" small />
 										<span>{{ selectedSettingsFields.length }} setting(s) selected for migration.</span>
 									</div>
 
-									<v-notice v-if="settingsFilterMode === 'selected' && selectedSettingsFields.length === 0 && !isLoadingSettings" type="warning" class="tab-notice">
+									<v-notice v-if="settingsFilterMode === 'selected' && (!selectedSettingsFields || selectedSettingsFields.length === 0) && !isLoadingSettings" type="warning" class="tab-notice">
 										<v-icon name="warning" small />
 										No settings selected. Settings migration will be skipped.
 									</v-notice>
@@ -1971,12 +2022,12 @@ export default defineComponent({
 										</div>
 									</div>
 
-									<div v-if="translationsFilterMode === 'filtered' && selectedLanguages.length > 0" class="selection-info">
+									<div v-if="translationsFilterMode === 'filtered' && selectedLanguages && selectedLanguages.length > 0" class="selection-info">
 										<v-icon name="check_circle" small />
 										<span>{{ selectedLanguages.length }} language(s) selected.</span>
 									</div>
 
-									<v-notice v-if="translationsFilterMode === 'filtered' && selectedLanguages.length === 0 && !isLoadingLanguages" type="warning" class="tab-notice">
+									<v-notice v-if="translationsFilterMode === 'filtered' && (!selectedLanguages || selectedLanguages.length === 0) && !isLoadingLanguages" type="warning" class="tab-notice">
 										<v-icon name="warning" small />
 										No languages selected. Translations migration will be skipped.
 									</v-notice>

--- a/packages/migration-bundle/src/migration-module/module.vue
+++ b/packages/migration-bundle/src/migration-module/module.vue
@@ -192,6 +192,18 @@ export default defineComponent({
 		const translationKeyPattern = ref<string>('');
 		const isLoadingLanguages = ref<boolean>(false);
 
+		// Issue #014: Bookmarks (Presets) filtering
+		const bookmarksFilterMode = ref<'all' | 'selected'>('all');
+		const availableBookmarks = ref<Array<{ text: string; value: string }>>([]);
+		const selectedBookmarks = ref<string[]>([]);
+		const isLoadingBookmarks = ref<boolean>(false);
+
+		// Issue #014: Insights (Dashboards) filtering
+		const insightsFilterMode = ref<'all' | 'selected'>('all');
+		const availableInsights = ref<Array<{ text: string; value: string; panelCount: number }>>([]);
+		const selectedInsights = ref<string[]>([]);
+		const isLoadingInsights = ref<boolean>(false);
+
 		// Tab-based UI - active tab for granular options
 		const activeTab = ref<string[]>(['schema']);
 
@@ -381,6 +393,78 @@ export default defineComponent({
 			}
 		};
 
+		// Issue #014: Load available bookmarks (presets)
+		const loadBookmarks = async () => {
+			isLoadingBookmarks.value = true;
+			try {
+				const response = await api.get('/presets', {
+					params: {
+						fields: ['id', 'bookmark', 'collection', 'icon', 'color'],
+						limit: -1,
+					},
+				});
+				const presetsData = response.data.data || [];
+				availableBookmarks.value = presetsData
+					.filter((p: any) => p.bookmark) // Only include named bookmarks
+					.map((p: any) => ({
+						text: p.bookmark || `Preset ${p.id}`,
+						value: String(p.id),
+					}))
+					.sort((a: any, b: any) => a.text.localeCompare(b.text));
+			}
+			catch (error) {
+				console.error('Failed to load bookmarks:', error);
+			}
+			finally {
+				isLoadingBookmarks.value = false;
+			}
+		};
+
+		// Issue #014: Load available insights (dashboards)
+		const loadInsights = async () => {
+			isLoadingInsights.value = true;
+			try {
+				// Fetch dashboards
+				const dashboardsResponse = await api.get('/dashboards', {
+					params: {
+						fields: ['id', 'name', 'icon', 'color'],
+						limit: -1,
+					},
+				});
+				const dashboardsData = dashboardsResponse.data.data || [];
+
+				// Fetch panels to count per dashboard
+				const panelsResponse = await api.get('/panels', {
+					params: {
+						fields: ['id', 'dashboard'],
+						limit: -1,
+					},
+				});
+				const panelsData = panelsResponse.data.data || [];
+
+				// Count panels per dashboard
+				const panelCounts: Record<string, number> = {};
+				panelsData.forEach((panel: any) => {
+					const dashboardId = panel.dashboard;
+					panelCounts[dashboardId] = (panelCounts[dashboardId] || 0) + 1;
+				});
+
+				availableInsights.value = dashboardsData
+					.map((d: any) => ({
+						text: d.name || `Dashboard ${d.id}`,
+						value: String(d.id),
+						panelCount: panelCounts[d.id] || 0,
+					}))
+					.sort((a: any, b: any) => a.text.localeCompare(b.text));
+			}
+			catch (error) {
+				console.error('Failed to load insights:', error);
+			}
+			finally {
+				isLoadingInsights.value = false;
+			}
+		};
+
 		// Load Users tab data when tab becomes active
 		watch(activeTab, (tab) => {
 			if (tab[0] === 'users' && availableRoles.value.length === 0) {
@@ -393,6 +477,14 @@ export default defineComponent({
 			// Issue #013: Load languages when Translations tab becomes active
 			if (tab[0] === 'translations' && availableLanguages.value.length === 0) {
 				loadLanguages();
+			}
+			// Issue #014: Load bookmarks when Bookmarks tab becomes active
+			if (tab[0] === 'presets' && availableBookmarks.value.length === 0) {
+				loadBookmarks();
+			}
+			// Issue #014: Load insights when Insights tab becomes active
+			if (tab[0] === 'dashboards' && availableInsights.value.length === 0) {
+				loadInsights();
 			}
 		});
 
@@ -443,6 +535,14 @@ export default defineComponent({
 					// Fix: Ensure 'files' is always included in options (backward compatibility)
 					if (!options.includes('files')) {
 						options = [...options, 'files'];
+					}
+					// Fix: Ensure 'settings' is always included in options
+					if (!options.includes('settings')) {
+						options = [...options, 'settings'];
+					}
+					// Fix: Ensure 'translations' is always included in options
+					if (!options.includes('translations')) {
+						options = [...options, 'translations'];
 					}
 					migrationOptionsSelections.value = options;
 				}
@@ -498,6 +598,14 @@ export default defineComponent({
 				// Fix: Ensure 'files' is always included in preset options (backward compatibility)
 				if (!selectedOptions.includes('files')) {
 					selectedOptions = [...selectedOptions, 'files'];
+				}
+				// Fix: Ensure 'settings' is always included in preset options
+				if (!selectedOptions.includes('settings')) {
+					selectedOptions = [...selectedOptions, 'settings'];
+				}
+				// Fix: Ensure 'translations' is always included in preset options
+				if (!selectedOptions.includes('translations')) {
+					selectedOptions = [...selectedOptions, 'translations'];
 				}
 				migrationOptionsSelections.value = selectedOptions;
 
@@ -772,6 +880,16 @@ export default defineComponent({
 				}
 			}
 
+			// Issue #014: Add bookmarks (presets) filtering to scope
+			if (scope.presets && bookmarksFilterMode.value === 'selected') {
+				extendedScope.selectedPresets = selectedBookmarks.value;
+			}
+
+			// Issue #014: Add insights (dashboards) filtering to scope
+			if (scope.dashboards && insightsFilterMode.value === 'selected') {
+				extendedScope.selectedDashboards = selectedInsights.value;
+			}
+
 			// Files defaults to true if content is selected (backward compatibility)
 			if (scope.content && !migrationOptionsSelections.value?.includes('files')) {
 				extendedScope.files = true;
@@ -871,6 +989,16 @@ export default defineComponent({
 			selectedLanguages,
 			translationKeyPattern,
 			isLoadingLanguages,
+			// Issue #014: Bookmarks (Presets) filtering
+			bookmarksFilterMode,
+			availableBookmarks,
+			selectedBookmarks,
+			isLoadingBookmarks,
+			// Issue #014: Insights (Dashboards) filtering
+			insightsFilterMode,
+			availableInsights,
+			selectedInsights,
+			isLoadingInsights,
 		};
 	},
 });
@@ -1033,11 +1161,18 @@ export default defineComponent({
 								Users
 							</v-tab>
 							<v-tab
-								v-if="migrationOptionsSelections?.includes('flows')"
-								value="flows"
+								v-if="migrationOptionsSelections?.includes('presets')"
+								value="presets"
 							>
-								<v-icon name="bolt" small />
-								Flows
+								<v-icon name="bookmark" small />
+								Bookmarks
+							</v-tab>
+							<v-tab
+								v-if="migrationOptionsSelections?.includes('dashboards')"
+								value="dashboards"
+							>
+								<v-icon name="insights" small />
+								Insights
 							</v-tab>
 							<v-tab
 								v-if="migrationOptionsSelections?.includes('extensions')"
@@ -1045,6 +1180,13 @@ export default defineComponent({
 							>
 								<v-icon name="extension" small />
 								Extensions
+							</v-tab>
+							<v-tab
+								v-if="migrationOptionsSelections?.includes('flows')"
+								value="flows"
+							>
+								<v-icon name="bolt" small />
+								Flows
 							</v-tab>
 							<v-tab
 								v-if="migrationOptionsSelections?.includes('settings')"
@@ -1307,6 +1449,121 @@ export default defineComponent({
 									<div class="dependency-hint">
 										<v-icon name="info" small />
 										<span>Dependencies: Policies require Roles, Permissions require Policies, User Accounts require Roles, Access requires Users + Policies. Selecting a user auto-selects their role.</span>
+									</div>
+								</div>
+							</v-tab-item>
+
+							<!-- Bookmarks Tab (Issue #014) -->
+							<v-tab-item value="presets">
+								<div class="tab-panel">
+									<h4>Bookmarks Filtering</h4>
+									<p class="tab-hint">Choose which bookmarks (presets) to migrate from the source instance.</p>
+
+									<div class="filter-mode-selector">
+										<v-radio
+											v-model="bookmarksFilterMode"
+											value="all"
+											label="Migrate all bookmarks"
+											:disabled="lockInterface"
+										/>
+										<v-radio
+											v-model="bookmarksFilterMode"
+											value="selected"
+											label="Select specific bookmarks"
+											:disabled="lockInterface"
+										/>
+									</div>
+
+									<v-select
+										v-if="bookmarksFilterMode === 'selected'"
+										v-model="selectedBookmarks"
+										:items="availableBookmarks"
+										:disabled="lockInterface || isLoadingBookmarks"
+										:loading="isLoadingBookmarks"
+										:multiple-preview-threshold="3"
+										item-text="text"
+										item-value="value"
+										placeholder="Select bookmarks to migrate..."
+										multiple
+										class="tab-select"
+									>
+										<template #prepend>
+											<v-icon name="bookmark" />
+										</template>
+									</v-select>
+
+									<div v-if="bookmarksFilterMode === 'selected' && selectedBookmarks.length > 0" class="selection-info">
+										<v-icon name="check_circle" small />
+										<span>{{ selectedBookmarks.length }} bookmark(s) selected for migration.</span>
+									</div>
+
+									<v-notice v-if="bookmarksFilterMode === 'selected' && selectedBookmarks.length === 0 && !isLoadingBookmarks" type="warning" class="tab-notice">
+										<v-icon name="warning" small />
+										No bookmarks selected. Bookmarks migration will be skipped.
+									</v-notice>
+
+									<div class="bookmarks-merge-note">
+										<v-icon name="info" small />
+										<span>Bookmarks are merged by ID. Existing bookmarks on the target will be updated if IDs match.</span>
+									</div>
+								</div>
+							</v-tab-item>
+
+							<!-- Insights Tab (Issue #014) -->
+							<v-tab-item value="dashboards">
+								<div class="tab-panel">
+									<h4>Insights Filtering</h4>
+									<p class="tab-hint">Choose which dashboards to migrate from the source instance. Associated panels will be included automatically.</p>
+
+									<div class="filter-mode-selector">
+										<v-radio
+											v-model="insightsFilterMode"
+											value="all"
+											label="Migrate all dashboards"
+											:disabled="lockInterface"
+										/>
+										<v-radio
+											v-model="insightsFilterMode"
+											value="selected"
+											label="Select specific dashboards"
+											:disabled="lockInterface"
+										/>
+									</div>
+
+									<v-select
+										v-if="insightsFilterMode === 'selected'"
+										v-model="selectedInsights"
+										:items="availableInsights.map(i => ({ text: `${i.text} (${i.panelCount} panels)`, value: i.value }))"
+										:disabled="lockInterface || isLoadingInsights"
+										:loading="isLoadingInsights"
+										:multiple-preview-threshold="3"
+										item-text="text"
+										item-value="value"
+										placeholder="Select dashboards to migrate..."
+										multiple
+										class="tab-select"
+									>
+										<template #prepend>
+											<v-icon name="insights" />
+										</template>
+									</v-select>
+
+									<div v-if="insightsFilterMode === 'selected' && selectedInsights.length > 0" class="selection-info">
+										<v-icon name="check_circle" small />
+										<span>
+											{{ selectedInsights.length }} dashboard(s) selected
+											({{ availableInsights.filter(i => selectedInsights.includes(i.value)).reduce((sum, i) => sum + i.panelCount, 0) }} panels will be included).
+										</span>
+									</div>
+
+									<v-notice v-if="insightsFilterMode === 'selected' && selectedInsights.length === 0 && !isLoadingInsights" type="warning" class="tab-notice">
+										<v-icon name="warning" small />
+										No dashboards selected. Insights migration will be skipped.
+									</v-notice>
+
+									<div class="insights-merge-note">
+										<v-icon name="info" small />
+										<span>Dashboards and their panels are migrated together. Selecting a dashboard automatically includes all its panels.</span>
 									</div>
 								</div>
 							</v-tab-item>
@@ -2086,8 +2343,11 @@ h3.skipped .icon i::after {
 }
 
 /* Issue #013: Settings and Translations tab styles */
+/* Issue #014: Bookmarks and Insights tab styles */
 .settings-merge-note,
-.translations-merge-note {
+.translations-merge-note,
+.bookmarks-merge-note,
+.insights-merge-note {
 	display: flex;
 	align-items: flex-start;
 	gap: 8px;
@@ -2100,7 +2360,9 @@ h3.skipped .icon i::after {
 }
 
 .settings-merge-note .v-icon,
-.translations-merge-note .v-icon {
+.translations-merge-note .v-icon,
+.bookmarks-merge-note .v-icon,
+.insights-merge-note .v-icon {
 	flex-shrink: 0;
 	margin-top: 2px;
 }

--- a/packages/migration-bundle/src/migration-module/module.vue
+++ b/packages/migration-bundle/src/migration-module/module.vue
@@ -163,7 +163,9 @@ export default defineComponent({
 		// Selected flows and extensions for granular selection
 		const selectedFlows = ref<string[]>([]);
 		const selectedExtensions = ref<string[]>([]);
-		const availableFlows = ref<Array<{ id: string; name: string }>>([]);
+		// Issue #017: Full data storage for flows (unfiltered)
+		const allFlows = ref<Array<{ id: string; name: string; collection: string | null }>>([]);
+		const availableFlows = ref<Array<{ id: string; name: string; collection: string | null }>>([]);
 		const availableExtensions = ref<Array<{ name: string; bundle: string | null; source: 'registry' | 'local' }>>([]);
 
 		// Phase 6: Users tab - specific item selection
@@ -194,7 +196,9 @@ export default defineComponent({
 
 		// Issue #014: Bookmarks (Presets) filtering
 		const bookmarksFilterMode = ref<'all' | 'selected'>('all');
-		const availableBookmarks = ref<Array<{ text: string; value: string }>>([]);
+		// Issue #017: Full data storage for bookmarks (unfiltered)
+		const allBookmarks = ref<Array<{ text: string; value: string; collection: string | null }>>([]);
+		const availableBookmarks = ref<Array<{ text: string; value: string; collection: string | null }>>([]);
 		const selectedBookmarks = ref<string[]>([]);
 		const isLoadingBookmarks = ref<boolean>(false);
 
@@ -249,6 +253,27 @@ export default defineComponent({
 			}
 		}, { immediate: true });
 
+		// Issue #017: Watch collection selection changes and update available bookmarks/flows
+		watch(
+			[selectedCollections, excludedCollections, collectionFilterMode],
+			() => {
+				filterAvailableBookmarks();
+				filterAvailableFlows();
+
+				// Clear selections that are no longer available
+				const availableBookmarkIds = new Set(availableBookmarks.value.map(b => b.value));
+				selectedBookmarks.value = selectedBookmarks.value.filter(id =>
+					availableBookmarkIds.has(id),
+				);
+
+				const availableFlowIds = new Set(availableFlows.value.map(f => f.id));
+				selectedFlows.value = selectedFlows.value.filter(id =>
+					availableFlowIds.has(id),
+				);
+			},
+			{ deep: true },
+		);
+
 		// Load available collections from Directus
 		const loadCollections = async () => {
 			isLoadingCollections.value = true;
@@ -270,6 +295,41 @@ export default defineComponent({
 			finally {
 				isLoadingCollections.value = false;
 			}
+		};
+
+		// Issue #017: Helper function to check if collection should be included in GUI
+		const shouldIncludeCollectionInGUI = (collection: string | null): boolean => {
+			// If no filtering active, include all (including null)
+			if (collectionFilterMode.value === 'all') return true;
+
+			// Include mode: null collection does NOT match any selected collection
+			if (collectionFilterMode.value === 'include') {
+				if (!collection) return false; // null != selected collections
+				if (selectedCollections.value.length === 0) return true;
+				return selectedCollections.value.includes(collection);
+			}
+
+			// Exclude mode: null collection is not in excluded list, so include it
+			if (collectionFilterMode.value === 'exclude') {
+				if (!collection) return true; // null is not excluded
+				return !excludedCollections.value.includes(collection);
+			}
+
+			return true;
+		};
+
+		// Issue #017: Filter bookmarks based on collection selection
+		const filterAvailableBookmarks = () => {
+			availableBookmarks.value = allBookmarks.value.filter(bookmark =>
+				shouldIncludeCollectionInGUI(bookmark.collection),
+			);
+		};
+
+		// Issue #017: Filter flows based on collection selection
+		const filterAvailableFlows = () => {
+			availableFlows.value = allFlows.value.filter(flow =>
+				shouldIncludeCollectionInGUI(flow.collection),
+			);
 		};
 
 		// Phase 6: Load functions for Users tab items
@@ -403,6 +463,7 @@ export default defineComponent({
 		};
 
 		// Issue #014: Load available bookmarks (presets)
+		// Issue #017: Store full data with collection field for GUI filtering
 		const loadBookmarks = async () => {
 			isLoadingBookmarks.value = true;
 			try {
@@ -413,13 +474,17 @@ export default defineComponent({
 					},
 				});
 				const presetsData = response.data.data || [];
-				availableBookmarks.value = presetsData
+				// Store full data with collection field
+				allBookmarks.value = presetsData
 					.filter((p: any) => p.bookmark) // Only include named bookmarks
 					.map((p: any) => ({
 						text: p.bookmark || `Preset ${p.id}`,
 						value: String(p.id),
+						collection: p.collection || null,
 					}))
 					.sort((a: any, b: any) => a.text.localeCompare(b.text));
+				// Apply initial filter
+				filterAvailableBookmarks();
 			}
 			catch (error) {
 				console.error('Failed to load bookmarks:', error);
@@ -764,13 +829,21 @@ export default defineComponent({
 		initialize();
 
 		// Fetch available flows and extensions
+		// Issue #017: Include flow options for collection filtering in GUI
 		const fetchAvailableData = async () => {
 			try {
 				const [flowsResponse, extensionsResponse] = await Promise.all([
-					api.get('/flows', { params: { fields: ['id', 'name'], limit: -1 } }),
+					api.get('/flows', { params: { fields: ['id', 'name', 'options'], limit: -1 } }),
 					api.get('/extensions'),
 				]);
-				availableFlows.value = flowsResponse.data.data || [];
+				// Store full data with collection from options
+				allFlows.value = (flowsResponse.data.data || []).map((f: any) => ({
+					id: f.id,
+					name: f.name,
+					collection: f.options?.collection || null,
+				}));
+				// Apply initial filter
+				filterAvailableFlows();
 				availableExtensions.value = (extensionsResponse.data.data || []).map((ext: any) => ({
 					name: ext.schema?.name || ext.id,
 					bundle: ext.bundle,
@@ -1024,6 +1097,8 @@ export default defineComponent({
 			usersGranular,
 			selectedFlows,
 			selectedExtensions,
+			// Issue #017: allFlows for showing hidden count
+			allFlows,
 			availableFlows,
 			availableExtensions,
 			// Tab-based UI
@@ -1051,7 +1126,9 @@ export default defineComponent({
 			translationKeyPattern,
 			isLoadingLanguages,
 			// Issue #014: Bookmarks (Presets) filtering
+			// Issue #017: allBookmarks for showing hidden count
 			bookmarksFilterMode,
+			allBookmarks,
 			availableBookmarks,
 			selectedBookmarks,
 			isLoadingBookmarks,
@@ -1604,6 +1681,16 @@ export default defineComponent({
 										/>
 									</div>
 
+									<!-- Issue #017: Show notice when bookmarks are filtered by collection -->
+									<v-notice
+										v-if="allBookmarks.length > availableBookmarks.length"
+										type="info"
+										class="tab-notice"
+									>
+										{{ allBookmarks.length - availableBookmarks.length }} bookmark(s) hidden
+										(collection not selected for migration).
+									</v-notice>
+
 									<v-select
 										v-if="bookmarksFilterMode === 'selected'"
 										v-model="selectedBookmarks"
@@ -1703,6 +1790,16 @@ export default defineComponent({
 								<div class="tab-panel">
 									<h4>Flow Selection</h4>
 									<p class="tab-hint">Select specific flows to migrate, or leave empty for all.</p>
+
+									<!-- Issue #017: Show notice when flows are filtered by collection -->
+									<v-notice
+										v-if="allFlows.length > availableFlows.length"
+										type="info"
+										class="tab-notice"
+									>
+										{{ allFlows.length - availableFlows.length }} flow(s) hidden
+										(trigger collection not selected for migration).
+									</v-notice>
 
 									<v-select
 										v-model="selectedFlows"

--- a/packages/migration-bundle/src/types/extension.ts
+++ b/packages/migration-bundle/src/types/extension.ts
@@ -172,6 +172,7 @@ export interface Translation {
 }
 
 export interface Scope {
+	schema: boolean;
 	users: boolean;
 	content: boolean;
 	comments: boolean;
@@ -180,6 +181,11 @@ export interface Scope {
 	extensions: boolean;
 	flows: boolean;
 	force: boolean;
+	// Collection-level filtering
+	selectedCollections?: string[];
+	excludedCollections?: string[];
+	// Content-specific collection selection (subset of selectedCollections)
+	contentCollections?: string[];
 }
 
 ;

--- a/packages/migration-bundle/src/types/extension.ts
+++ b/packages/migration-bundle/src/types/extension.ts
@@ -205,7 +205,12 @@ export interface Scope {
 	flows: boolean;
 	selectedFlows?: string[];
 	settings: boolean;
+	// Settings filtering (Issue #013)
+	selectedSettings?: string[];
 	translations: boolean;
+	// Translations filtering (Issue #013)
+	selectedLanguages?: string[];
+	translationKeyPattern?: string;
 	force: boolean;
 	// Collection-level filtering
 	selectedCollections?: string[];

--- a/packages/migration-bundle/src/types/extension.ts
+++ b/packages/migration-bundle/src/types/extension.ts
@@ -199,7 +199,11 @@ export interface Scope {
 	selectedFolders?: string[];
 	comments: boolean;
 	presets: boolean;
+	// Presets filtering (Issue #014)
+	selectedPresets?: string[];
 	dashboards: boolean;
+	// Dashboards filtering (Issue #014)
+	selectedDashboards?: string[];
 	extensions: boolean;
 	selectedExtensions?: string[];
 	flows: boolean;

--- a/packages/migration-bundle/src/types/extension.ts
+++ b/packages/migration-bundle/src/types/extension.ts
@@ -171,15 +171,41 @@ export interface Translation {
 	value: string;
 }
 
+export interface UsersGranularOptions {
+	roles: boolean;
+	policies: boolean;
+	permissions: boolean;
+	userAccounts: boolean;
+	access: boolean;
+}
+
+// Phase 6: Specific item selection for Users tab
+export interface UsersSelectionOptions {
+	selectedRoles?: string[];
+	selectedPolicies?: string[];
+	selectedPermissions?: number[];
+	selectedUsers?: string[];
+	selectedAccess?: number[];
+}
+
 export interface Scope {
 	schema: boolean;
 	users: boolean;
+	usersGranular?: UsersGranularOptions;
+	usersSelection?: UsersSelectionOptions;
 	content: boolean;
+	files: boolean;
+	folders: boolean;
+	selectedFolders?: string[];
 	comments: boolean;
 	presets: boolean;
 	dashboards: boolean;
 	extensions: boolean;
+	selectedExtensions?: string[];
 	flows: boolean;
+	selectedFlows?: string[];
+	settings: boolean;
+	translations: boolean;
 	force: boolean;
 	// Collection-level filtering
 	selectedCollections?: string[];

--- a/packages/migration-bundle/src/types/extension.ts
+++ b/packages/migration-bundle/src/types/extension.ts
@@ -198,6 +198,8 @@ export interface Scope {
 	folders: boolean;
 	selectedFolders?: string[];
 	comments: boolean;
+	// Comments filtering (Issue #009)
+	includeCommentsForContent?: boolean;
 	presets: boolean;
 	// Presets filtering (Issue #014)
 	selectedPresets?: string[];

--- a/packages/migration-bundle/src/utils/filter-schema-diff.ts
+++ b/packages/migration-bundle/src/utils/filter-schema-diff.ts
@@ -1,0 +1,72 @@
+import type { SchemaDiffOutput } from '@directus/sdk';
+
+/**
+ * Filters a schema diff to exclude directus_* system collections
+ * and optionally limit to specific collections.
+ */
+export function filterSchemaDiff(
+	diff: SchemaDiffOutput,
+	includedCollections?: Set<string>
+): SchemaDiffOutput {
+	// If no diff or no hash (meaning no changes), return as-is
+	if (!diff || !('hash' in diff) || !('diff' in diff)) {
+		return diff;
+	}
+
+	const shouldInclude = (collectionName: string): boolean => {
+		// Always exclude directus_* system collections
+		if (collectionName.startsWith('directus_')) {
+			return false;
+		}
+		// If we have a specific set of collections to include, check against it
+		if (includedCollections && includedCollections.size > 0) {
+			return includedCollections.has(collectionName);
+		}
+		// Otherwise include all non-system collections
+		return true;
+	};
+
+	const filteredDiff = { ...diff.diff };
+
+	// Filter collections
+	if (filteredDiff.collections && Array.isArray(filteredDiff.collections)) {
+		filteredDiff.collections = filteredDiff.collections.filter((c: any) =>
+			shouldInclude(c.collection)
+		);
+	}
+
+	// Filter fields
+	if (filteredDiff.fields && Array.isArray(filteredDiff.fields)) {
+		filteredDiff.fields = filteredDiff.fields.filter((f: any) =>
+			shouldInclude(f.collection)
+		);
+	}
+
+	// Filter relations
+	if (filteredDiff.relations && Array.isArray(filteredDiff.relations)) {
+		filteredDiff.relations = filteredDiff.relations.filter((r: any) =>
+			shouldInclude(r.collection) &&
+			(r.related_collection === null || shouldInclude(r.related_collection))
+		);
+	}
+
+	return {
+		...diff,
+		diff: filteredDiff,
+	};
+}
+
+/**
+ * Extracts the set of collection names from a schema snapshot
+ */
+export function getCollectionsFromSchema(schema: any): Set<string> {
+	const collections = new Set<string>();
+	if (schema?.collections && Array.isArray(schema.collections)) {
+		for (const c of schema.collections) {
+			if (c.collection && !c.collection.startsWith('directus_')) {
+				collections.add(c.collection);
+			}
+		}
+	}
+	return collections;
+}

--- a/packages/migration-bundle/src/utils/filter-schema.ts
+++ b/packages/migration-bundle/src/utils/filter-schema.ts
@@ -1,0 +1,103 @@
+import type { Snapshot } from '@directus/types';
+import type { Scope } from '../types/extension';
+
+export function filterSchema(schema: Snapshot, scope: Scope): Snapshot {
+	const { selectedCollections, excludedCollections } = scope;
+
+	// Use process.stdout.write for logging (more reliable than console.log in some contexts)
+	const log = (msg: string) => {
+		try {
+			process.stdout.write(`[filter-schema] ${msg}\n`);
+		} catch {
+			// Fallback to console.log if process.stdout is not available
+			console.log(`[filter-schema] ${msg}`);
+		}
+	};
+
+	log(`Input collections count: ${schema.collections?.length || 0}`);
+	log(`Selected collections: ${JSON.stringify(selectedCollections || [])}`);
+	log(`Excluded collections: ${JSON.stringify(excludedCollections || [])}`);
+
+	// If no filtering specified, return full schema
+	if ((!selectedCollections || selectedCollections.length === 0) &&
+		(!excludedCollections || excludedCollections.length === 0)) {
+		log('No filtering specified, returning full schema');
+		return schema;
+	}
+
+	// Build initial set of included collections
+	const includedCollections = new Set<string>();
+
+	if (selectedCollections && selectedCollections.length > 0) {
+		// Include mode: start with selected collections
+		for (const collectionName of selectedCollections) {
+			// Skip directus_* system collections - they should not be in filtered schema
+			if (!collectionName.startsWith('directus_')) {
+				includedCollections.add(collectionName);
+			}
+		}
+	} else if (excludedCollections && excludedCollections.length > 0) {
+		// Exclude mode: start with all non-system collections, remove excluded
+		for (const c of schema.collections) {
+			if (!c.collection.startsWith('directus_') && !excludedCollections.includes(c.collection)) {
+				includedCollections.add(c.collection);
+			}
+		}
+	}
+
+	log(`Initial included collections (before group resolution): ${Array.from(includedCollections).join(', ')}`);
+
+	// Recursively add parent groups
+	// Collections can have a 'group' property in their meta that references a parent collection
+	let changed = true;
+	let iterations = 0;
+	const maxIterations = 100; // Safety limit
+
+	while (changed && iterations < maxIterations) {
+		changed = false;
+		iterations++;
+
+		for (const c of schema.collections) {
+			// If this collection is included and has a parent group
+			if (includedCollections.has(c.collection)) {
+				const parentGroup = (c as any).meta?.group;
+				if (parentGroup && !parentGroup.startsWith('directus_') && !includedCollections.has(parentGroup)) {
+					log(`Adding parent group '${parentGroup}' for collection '${c.collection}'`);
+					includedCollections.add(parentGroup);
+					changed = true;
+				}
+			}
+		}
+	}
+
+	if (iterations >= maxIterations) {
+		log('WARNING: Max iterations reached while resolving parent groups');
+	}
+
+	log(`Final included collections (after group resolution): ${Array.from(includedCollections).join(', ')}`);
+
+	// Filter function
+	const shouldInclude = (collectionName: string): boolean => {
+		// Always exclude directus_* system collections from filtered schema
+		if (collectionName.startsWith('directus_')) {
+			return false;
+		}
+		return includedCollections.has(collectionName);
+	};
+
+	const result: Snapshot = {
+		version: schema.version,
+		directus: schema.directus,
+		vendor: schema.vendor,
+		collections: schema.collections.filter(c => shouldInclude(c.collection)),
+		fields: schema.fields.filter(f => shouldInclude(f.collection)),
+		relations: schema.relations.filter(r =>
+			shouldInclude(r.collection) &&
+			(r.related_collection === null || shouldInclude(r.related_collection))
+		),
+	};
+
+	log(`Output: ${result.collections.length} collections, ${result.fields.length} fields, ${result.relations.length} relations`);
+
+	return result;
+}

--- a/packages/migration-bundle/src/utils/system-fields.ts
+++ b/packages/migration-bundle/src/utils/system-fields.ts
@@ -158,6 +158,7 @@ export const directusPolicyFields = [
 ];
 
 export const directusPresetFields = [
+	'id',
 	'bookmark',
 	'user',
 	'role',

--- a/packages/migration-bundle/src/utils/validate.ts
+++ b/packages/migration-bundle/src/utils/validate.ts
@@ -24,36 +24,39 @@ export async function validate_system({
 	if (!scope)
 		return false;
 
-	return !system_errors && (!scope.users || (
-		Array.isArray(roles) && roles.length > 0
-		&& Array.isArray(policies) && policies.length > 0
-		&& Array.isArray(permissions) && permissions.length > 0
-		&& Array.isArray(users) && users.length > 0
-		&& Array.isArray(access) && access.length > 0
+	// Get granular options for users - only validate what was requested
+	const usersGranular = scope.usersGranular || {
+		roles: true,
+		policies: true,
+		permissions: true,
+		userAccounts: true,
+		access: true,
+	};
+
+	// Users validation: check each granular option separately
+	const usersValid = !scope.users || (
+		(!usersGranular.roles || (Array.isArray(roles) && roles.length > 0))
+		&& (!usersGranular.policies || (Array.isArray(policies) && policies.length > 0))
+		&& (!usersGranular.permissions || Array.isArray(permissions))
+		&& (!usersGranular.userAccounts || Array.isArray(users))
+		&& (!usersGranular.access || Array.isArray(access))
 		&& Array.isArray(shares)
-	))
-	&& (!scope.content || (
-		Array.isArray(folders)
-	))
-	&& (!scope.dashboards || (
-		Array.isArray(dashboards)
-		&& Array.isArray(panels)
-	))
-	&& (!scope.flows || (
-		Array.isArray(flows)
-		&& Array.isArray(operations)
-	))
-	&& settings
-	&& Array.isArray(translations)
-	&& (!scope.presets || (
-		Array.isArray(presets) && presets.length > 0
-	))
-	&& (!scope.extensions || (
-		Array.isArray(extensions)
-	))
-	&& (!scope.comments || (
-		Array.isArray(comments)
-	));
+	);
+
+	// Settings and translations: only validate if scope enables them (default true for backward compatibility)
+	const shouldValidateSettings = scope.settings !== false;
+	const shouldValidateTranslations = scope.translations !== false;
+
+	return !system_errors
+		&& usersValid
+		&& (!scope.content || Array.isArray(folders))
+		&& (!scope.dashboards || (Array.isArray(dashboards) && Array.isArray(panels)))
+		&& (!scope.flows || (Array.isArray(flows) && Array.isArray(operations)))
+		&& (!shouldValidateSettings || settings !== null)
+		&& (!shouldValidateTranslations || Array.isArray(translations))
+		&& (!scope.presets || (Array.isArray(presets) && presets.length > 0))
+		&& (!scope.extensions || Array.isArray(extensions))
+		&& (!scope.comments || Array.isArray(comments));
 }
 
 export async function validate_data({


### PR DESCRIPTION
## Summary

This PR introduces comprehensive granular migration options with a completely redesigned tab-based UI, giving users fine-grained control over every aspect of their migration.

**Addresses:**
- Closes #266 (Migrate only selected collections / singletons)
- Closes #294 (Adding more options for Migration Module)
- Supersedes #302 (outdated PR with only collection-level selection)

## New Features

### Tab-Based UI Redesign
Complete redesign of the Migration Options interface with organized tabs:
- **Schema** - Include/exclude specific collections
- **Content** - Select collections for content migration
- **Files** - Filter by specific folders
- **Users** - Roles, policies, permissions, accounts, access rules
- **Flows** - Select specific flows by ID or name
- **Extensions** - Select specific extensions
- **Settings** - Select specific setting fields
- **Translations** - Filter by language and key pattern
- **Bookmarks** - Select specific bookmarks
- **Insights** - Select specific dashboards

### Users Granular Filtering
- Individual control over roles, policies, permissions, user accounts, and access rules
- Automatic dependency handling (selecting a user auto-selects their role)
- Item-level selection for each category

### Flows & Extensions Filtering
- Filter by ID (UUID) or human-readable name
- Bundle name support for extensions

### Files/Folders Filtering
- New Files tab with folder-based filtering
- Migrate only files from selected folders

### Settings & Translations
- Select specific settings fields
- Filter translations by language and key pattern

### Bookmarks & Insights
- Dedicated tabs for bookmark and dashboard management
- Individual item selection

### GUI Enhancements
- Collection context filtering: Bookmarks/Flows lists filter based on selected schema collections
- Local extensions warning notice
- Comments integration toggle for content migrations

## Bug Fixes

- **Tab Visibility Bug** - Fixed tabs disappearing after deselecting all items (Directus v-select null handling)
- **selectedExtensions Filter** - Now accepts both ID and schema.name
- **Empty usersSelection Skip** - Correctly skips empty selections
- **Null Collection Handling** - Fixed include/exclude modes for items with null collection refs
- **Comments Migration** - Moved outside content block for independent migration

## New Environment Variables

```bash
MIGRATION_BUNDLE_SELECTED_FLOWS=flow-uuid,My Flow Name
MIGRATION_BUNDLE_SELECTED_EXTENSIONS=@directus-labs/field-comments
MIGRATION_BUNDLE_SELECTED_FOLDERS=folder-uuid-1,folder-uuid-2
MIGRATION_BUNDLE_USERS_ROLES=true
MIGRATION_BUNDLE_USERS_POLICIES=true
MIGRATION_BUNDLE_USERS_PERMISSIONS=true
MIGRATION_BUNDLE_USERS_ACCOUNTS=true
MIGRATION_BUNDLE_USERS_ACCESS=true
```

## Breaking Changes

None. All changes are backward compatible.

## Test Plan

1. Install the extension on a Directus instance
2. Navigate to `/admin/migration`
3. Configure destination URL and token, click Check
4. Verify all tabs are visible and functional
5. Test selecting/deselecting items in each tab
6. Verify tab visibility remains stable after deselecting all items
7. Run a dry-run migration with granular selections
8. Verify only selected items are included in migration

## Files Changed

- `module.vue` - Major UI redesign with tabs
- `extract-system.ts` - Granular filtering logic
- `extract-data.ts` - Collection filtering
- `index.ts` - Endpoint logic updates
- `extension.ts` - Type definitions
- `filter-schema.ts` - Schema filtering utility
- `filter-schema-diff.ts` - Diff filtering utility
- `package.json` - Version bump to 1.3.0
- `CHANGELOG.md` - Full changelog for v1.3.0
- `README.md` - Updated documentation

---

🤖 Generated with [Claude Code](https://claude.ai/code)