### PR TITLE
Address Completion Interface: Include the placeId in the emitted properties

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -6,3 +6,4 @@
 - timio23
 - Dominic-Marcelino
 - ukmadlz
+- tobyaherbert

--- a/packages/address-completion-interface/package.json
+++ b/packages/address-completion-interface/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@directus-labs/address-completion-interface",
 	"type": "module",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "Use Google Places autocomplete Data API as an Address Completion interface",
 	"author": "Directus Labs",
 	"contributors": [

--- a/packages/address-completion-interface/src/interface.vue
+++ b/packages/address-completion-interface/src/interface.vue
@@ -16,6 +16,7 @@ interface AutocompleteLocation {
 type Coordinates = [number, number];
 
 interface GeoProperties {
+	placeId: string;
 	displayName: string;
 	country: string; // ISO 3166-2
 	administrativeArea: string;
@@ -197,7 +198,10 @@ async function onPlaceSelected(location: AutocompleteLocation) {
 				coordinates: [lng, lat],
 				type: 'Point',
 			},
-			properties: getProperties(placeData.place),
+			properties: {
+				placeId: selectedPlaceId.value,
+				...getProperties(placeData.place),
+			},
 			type: 'Feature',
 		};
 

--- a/packages/address-completion-interface/src/interface.vue
+++ b/packages/address-completion-interface/src/interface.vue
@@ -199,8 +199,8 @@ async function onPlaceSelected(location: AutocompleteLocation) {
 				type: 'Point',
 			},
 			properties: {
-				placeId: selectedPlaceId.value,
 				...getProperties(placeData.place),
+				placeId: selectedPlaceId.value,
 			},
 			type: 'Feature',
 		};


### PR DESCRIPTION
This PR updates the **Address Completion Interface** extension to include the `placeId` field in the emitted properties, allowing it to be retrieved from the database later. See #304 for more details.