### PR TITLE
fix(tree-view-table-layout): support Directus 12

### DIFF
--- a/packages/tree-view-table-layout/package.json
+++ b/packages/tree-view-table-layout/package.json
@@ -41,7 +41,7 @@
 		"type": "layout",
 		"path": "dist/index.js",
 		"source": "src/index.ts",
-		"host": "^10.10.0 || ^11.0.0"
+		"host": "^10.10.0 || ^11.0.0 || ^12.0.0"
 	},
 	"scripts": {
 		"build": "directus-extension build",

--- a/packages/tree-view-table-layout/src/components/table-header.vue
+++ b/packages/tree-view-table-layout/src/components/table-header.vue
@@ -2,7 +2,10 @@
 import type { ShowSelect } from '@directus/extensions';
 // import { Header, Sort } from './types';
 import type { Header, Sort } from '../core-clones/components/v-table/types';
-import { useSync } from '@directus/composables';
+// useSync comes from the SDK, not @directus/composables: Directus 12's app bundle does not
+// provide @directus/composables in its import map, so importing it directly leaves an
+// unresolvable bare specifier that breaks the whole extension at runtime. The SDK re-exports it.
+import { useSync } from '@directus/extensions-sdk';
 import { clone, throttle } from 'lodash';
 import { computed, ref, useSlots } from 'vue';
 import { useI18n } from 'vue-i18n';

--- a/packages/tree-view-table-layout/src/core-clones/utils/get-route.ts
+++ b/packages/tree-view-table-layout/src/core-clones/utils/get-route.ts
@@ -1,4 +1,9 @@
-import { isSystemCollection } from '@directus/system-data';
+// Inlined from @directus/system-data: Directus 12's app bundle does not provide that package in
+// its import map, so importing it directly leaves an unresolvable bare specifier that breaks the
+// whole extension at runtime. The check is just the documented "directus_" system-prefix test.
+function isSystemCollection(collection: string): boolean {
+	return typeof collection === 'string' && collection.startsWith('directus_');
+}
 
 const accessibleSystemCollections = {
 	directus_users: { route: '/users' },


### PR DESCRIPTION
## Problem

The Tree View Table layout does not work on Directus 12. The layout never appears in the **Layout** picker, and because the failure happens while the extension bundle is being evaluated, *none* of the layout registers — there is no partial degradation, the whole extension is dead on a v12 instance.

## Root cause

Two independent things combine here:

1. **Host range excludes `^12`.** `package.json` declares `directus:host` as `^10.10.0 || ^11.0.0`, so even once the code loads, Directus 12 considers the extension incompatible and filters it out of the picker.

2. **Two bare specifiers are not in the Directus 12 app import map.** The built code imports:
   - `useSync` from `@directus/composables`
   - `isSystemCollection` from `@directus/system-data`

   Directus 12's app bundle does not expose either of those packages in the import map it hands to extensions. An unresolvable bare specifier throws at module-evaluation time, and since these imports sit at the top of files that are pulled into the layout's entry graph, the throw takes the **entire** extension bundle down with it. That is why bumping the host range alone is not enough — the layout still would not load.

## Fix

- Bump `directus:host` to `^10.10.0 || ^11.0.0 || ^12.0.0`.
- Import `useSync` from `@directus/extensions-sdk` instead of `@directus/composables`. The SDK re-exports `useSync`, and the SDK *is* present in the v12 import map, so the specifier resolves. Behaviour is identical.
- Inline `isSystemCollection` in `core-clones/utils/get-route.ts` as the documented system-prefix check (`collection.startsWith('directus_')`) rather than importing `@directus/system-data`. This is the same logic that package ships, with no runtime dependency on a package the app does not provide to extensions.

Both source files carry a short comment explaining *why* the import was changed, so a future contributor does not innocently "clean up" the inline back into a bare import and re-break v12.

## Verification

- Built the package from source and loaded it as a local extension on a Directus 12 instance: the layout now appears in the **Layout** picker and registers cleanly (no console error during bundle evaluation).
- Confirmed the layout still loads on Directus 11 (the SDK re-export and the inlined helper are both available there too), so this is additive, not a v12-only swap.
- `isSystemCollection` behaviour spot-checked: `directus_users` etc. still route to their system pages, non-system collections fall through unchanged.

No behavioural change to the tree itself — this PR is purely about making the existing layout load on Directus 12 (and stay loading on 10/11).
