### PR TITLE
perf(tree-view-table-layout): PATCH only the rows that actually changed on drag-save

### DIFF
--- a/packages/tree-view-table-layout/src/index.ts
+++ b/packages/tree-view-table-layout/src/index.ts
@@ -544,12 +544,45 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			return { saveEdits };
 
 			async function saveEdits(edits: Record<PrimaryKey, Item>) {
+				const pk = primaryKeyField.value?.field ?? 'id';
+				const parentFieldName = parentField.value;
+				// Normalise an m2o value (object {pk}, scalar, or null) to its related key for comparison.
+				const relKey = (value: any) =>
+					value == null ? null : (typeof value === 'object' ? value[pk] : value);
+
+				// Only PATCH rows whose value actually changed. Upstream re-patches EVERY row's sort
+				// key on any drag (600+ requests), which is slow and lets a fast reload race a
+				// reparent queued behind those writes. We also send parent edits first so a reparent
+				// persists immediately, before the (now minimal) sort-position updates.
+				const entries = Object.entries(edits).sort(([, a], [, b]) => {
+					const aParent = parentFieldName && parentFieldName in (a as object) ? 0 : 1;
+					const bParent = parentFieldName && parentFieldName in (b as object) ? 0 : 1;
+					return aParent - bParent;
+				});
+
 				try {
-					for (const [id, payload] of Object.entries(edits)) {
-						await api.patch(
-							`${getEndpoint(collection.value!)}/${id}`,
-							payload,
+					for (const [id, payload] of entries) {
+						const original = items.value.find(
+							(item) => String(item[pk]) === String(id),
 						);
+
+						const changed: Item = {};
+
+						for (const [field, value] of Object.entries(payload)) {
+							const isParent = field === parentFieldName;
+							const before = isParent ? relKey(original?.[field]) : original?.[field];
+							const after = isParent ? relKey(value) : value;
+
+							if (original === undefined || before !== after)
+								changed[field] = value;
+						}
+
+						if (Object.keys(changed).length > 0) {
+							await api.patch(
+								`${getEndpoint(collection.value!)}/${id}`,
+								changed,
+							);
+						}
 					}
 				}
 				catch (error: any) {


### PR DESCRIPTION
## Problem

Every drag (reorder or reparent) saves by PATCHing **every** edited row, even when a row's payload is identical to what is already in the database. On a moderately sized tree this is hundreds of redundant write requests per drag. Two real consequences:

1. **Slow saves** — the save fans out into 600+ sequential PATCHes on a large collection, most of them no-ops that still cost a round trip.
2. **A reload race** — because all those writes are queued sequentially and a reparent can sit at the back of the queue, a fast user reload can land before the meaningful write (the new `parent`) has been persisted, so the reparent appears to be lost.

## Root cause

`saveEdits` in `src/index.ts` loops over `Object.entries(edits)` and unconditionally PATCHes each row's full payload. There is no comparison against the current value, so unchanged sort keys are written back identically, and there is no ordering, so a structural change (`parent`) has no priority over bulk sort-position updates.

## Fix

In `saveEdits`:

- **Diff each field against the current item** (`items.value`) and build a `changed` payload containing only fields whose value actually differs. M2O values are normalised before comparison via a small `relKey` helper (handles the `{ [pk]: ... }` object form, the scalar-key form, and `null`) so an unchanged parent expressed in a different shape is not treated as a change. Rows with no real change are skipped entirely (no PATCH).
- **Send parent edits first.** Entries are sorted so rows whose payload includes the parent field are PATCHed before pure sort-position rows. This persists a reparent immediately, ahead of the now-minimal set of sort updates, closing the reload race.
- New rows (no matching original) still send their full payload, since there is nothing to diff against.

## Verification

- Reordering two siblings now issues only the PATCHes for the rows that moved, instead of re-writing the whole collection's sort key.
- Reparenting a node persists the `parent` change first; a fast reload immediately after the drag keeps the new parent.
- A drag that results in no net change produces **zero** PATCH requests.
- Confirmed unchanged M2O parent values (object vs scalar representation) are correctly treated as unchanged and not re-sent.

No change to the on-disk result of a save — only which requests are sent, and in what order.
