### PR TITLE
feat(tree-view-table-layout): shift-click a chevron to expand/collapse the whole subtree

### DIFF
--- a/packages/tree-view-table-layout/src/components/table-row.vue
+++ b/packages/tree-view-table-layout/src/components/table-row.vue
@@ -131,7 +131,7 @@ function usePreventClickAfterDragging({ mouseDownHandler, clickHandler }) {
 					name="expand_more"
 					class="collapse-btn"
 					:class="{ 'children-collapsed': childrenCollapsed }"
-					@click.stop="$emit('toggle-children')"
+					@click.stop="$emit('toggle-children', $event.shiftKey)"
 				/>
 			</div>
 		</td>

--- a/packages/tree-view-table-layout/src/components/v-table.vue
+++ b/packages/tree-view-table-layout/src/components/v-table.vue
@@ -581,12 +581,50 @@ function useTreeView({
 			return collapsedState.value.includes(id);
 		}
 
-		function onToggleChildren(item: Item) {
+		function onToggleChildren(item: Item, deep = false) {
 			if (!item[childrenKey]?.length)
 				return;
 
+			if (deep) {
+				toggleChildrenDeep(item);
+				return;
+			}
+
 			item[collapsedKey] = toggleItem(item[itemKey.value]);
 			collapseChildren(item[itemKey.value], item[childrenKey]);
+		}
+
+		// Shift-click: expand/collapse the ENTIRE subtree. Pick a target state (the opposite of
+		// the clicked node's current one) and drive the clicked node + every descendant container
+		// to it, so one gesture fully unfolds or folds the branch instead of a single level.
+		function toggleChildrenDeep(item: Item) {
+			const target = !isCollapsed(item[itemKey.value]);
+			const subtree: PrimaryKey[] = item[childrenKey] ?? [];
+			const containerIds: PrimaryKey[] = [item[itemKey.value]];
+
+			for (const internalItem of internalItems.value) {
+				if (
+					subtree.includes(internalItem[itemKey.value])
+					&& internalItem[childrenKey]?.length
+				) {
+					containerIds.push(internalItem[itemKey.value]);
+				}
+			}
+
+			for (const id of containerIds) {
+				if (isCollapsed(id) === target)
+					continue;
+
+				const node = internalItems.value.find(
+					(internalItem) => internalItem[itemKey.value] === id,
+				);
+
+				if (!node)
+					continue;
+
+				node[collapsedKey] = toggleItem(id);
+				collapseChildren(id, node[childrenKey]);
+			}
 		}
 
 		function toggleItem(id: PrimaryKey): boolean {
@@ -755,7 +793,7 @@ function useTreeView({
 						:has-click-listener="!disabled && clickable"
 						:height="rowHeight"
 						@mouseover.prevent="onDragOver"
-						@toggle-children="onToggleChildren(item)"
+						@toggle-children="(deep) => onToggleChildren(item, deep)"
 						@click="
 							!disabled && clickable
 								? $emit('click:row', { item, event: $event })


### PR DESCRIPTION
## Problem

The expand/collapse chevron only ever toggles **one** level. Fully opening or closing a deep branch means clicking down (or up) through every intermediate node by hand, which is tedious on large trees.

## Fix

Add a power-user gesture: **shift-click** a chevron to expand or collapse the **entire** subtree under that node in one action. A plain click is unchanged (single level).

Implementation:

- `src/components/table-row.vue` — the chevron's click handler now forwards the modifier state: `$emit('toggle-children', $event.shiftKey)`. A normal click emits `false`, a shift-click emits `true`.
- `src/components/v-table.vue` — `onToggleChildren(item, deep = false)` gains a `deep` flag. When `deep` is true it delegates to a new `toggleChildrenDeep(item)`, which:
  - picks a single **target collapsed state** (the opposite of the clicked node's current state), so the whole branch ends up consistently open *or* consistently closed regardless of the mixed states it started in;
  - collects the clicked node plus every descendant container (descendants that themselves have children) from `internalItems`;
  - drives only the containers that are not already at the target state to that state, reusing the existing `toggleItem` / `collapseChildren` primitives.

  The template binding is updated to pass the flag through: `@toggle-children="(deep) => onToggleChildren(item, deep)"`.

Defaulting `deep` to `false` keeps the single-level behaviour for every existing caller and for plain clicks.

## Verification

- Shift-clicking a collapsed top-level node expands the full branch (all nested containers open) in one gesture; shift-clicking it again collapses the whole branch.
- Shift-clicking a branch that is in a mixed state (some children open, some closed) drives the entire branch to a single consistent state rather than toggling each node independently.
- Plain (non-shift) clicks still toggle exactly one level, unchanged.

## Note for reviewers

This PR touches `src/components/table-row.vue`, but **only the `@click` emit hunk** in the `<template>` (forwarding `$event.shiftKey`). A separate PR ("fix: point the collapsed-row chevron right") also touches this file, but in a **different, non-overlapping hunk** — the `transform: rotate(...)` rule in the `<style>` block. The two changes are independent and do not conflict.
